### PR TITLE
allow display of error messages arising from device connection

### DIFF
--- a/wasatch/AndorDevice.py
+++ b/wasatch/AndorDevice.py
@@ -353,7 +353,7 @@ class AndorDevice(InterfaceDevice):
 
     def connect(self) -> SpectrometerResponse:
         if self.dll_fail:
-            return SpectrometerResponse(data=False,error_lvl=ErrorLevel.high,error_msg="couldn't load Andor dll")
+            return SpectrometerResponse(False, error_msg="can't find Andor DLL; please confirm Andor Driver Pack 2 installed")
 
         cameraHandle = c_int()
         self.check_result(self.driver.GetCameraHandle(self.spec_index, byref(cameraHandle)), "GetCameraHandle")
@@ -364,7 +364,7 @@ class AndorDevice(InterfaceDevice):
             self.check_result(self.driver.Initialize(path_to_ini), "Initialize")
         except:
             log.error("Andor.Initialize failed", exc_info=1)
-            return SpectrometerResponse(data=False, error_lvl=ErrorLevel.high, error_msg="Andor initialization failed")
+            return SpectrometerResponse(False, error_msg="Andor initialization failed")
 
         self.get_serial_number()
         self.init_tec_setpoint()

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -215,7 +215,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
                     log.warn("Hardware Failure in setConfiguration. Resource busy error. Attempting to reattach driver by reset.")
                     self.device_type.reset(dev)
                     sleep_ms = 10 ** retries # 10^3 ms = 1sec max delay
-                    sleep(sleep_ms / 1.0) 
+                    sleep(sleep_ms / 1000.0) 
                     return self.connect(retries=retries+1) 
 
                 self.connecting = False

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -214,7 +214,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 if "Resource busy" in str(exc) and retries <= 3:
                     log.warn("Hardware Failure in setConfiguration. Resource busy error. Attempting to reattach driver by reset.")
                     self.device_type.reset(dev)
-                    sleep(10 ** retries) # 10^3 ms = 1sec max delay
+                    sleep_ms = 10 ** retries # 10^3 ms = 1sec max delay
+                    sleep(sleep_ms / 1.0) 
                     return self.connect(retries=retries+1) 
 
                 self.connecting = False

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -186,9 +186,9 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 break
 
         if device is None:
-            log.debug("FID.connect: unable to find DeviceID %s", str(self.device_id))
+            log.debug(f"FID.connect: unable to find DeviceID {self.device_id}")
             self.connecting = False
-            return False
+            return SpectrometerResponse(data=False, poison_pill=True, error_msg=f"unable to find DeviceID {self.device_id}")
         else:
             log.debug("FID.connect: matched DeviceID %s", str(self.device_id))
 
@@ -209,8 +209,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 if "Resource busy" in str(exc):
                     log.warn("Hardware Failure in setConfiguration. Resource busy error. Attempting to reattach driver by reset.")
                     self.device_type.reset(dev)
-                    connect()
-                    return self.connected
+                    connect() # MZ: I don't see how this could work?  What is connect()?
+                    return SpectrometerResponse(data=self.connected)
                 log.warn("Hardware Failure in setConfiguration", exc_info=1)
                 self.connecting = False
                 raise
@@ -257,7 +257,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         if not self._read_eeprom():
             log.error("failed to read EEPROM")
             self.connecting = False
-            return SpectrometerResponse(False)
+            return SpectrometerResponse(False, error_msg="Failed to read EEPROM")
 
         # ######################################################################
         # Laser

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -188,7 +188,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         if device is None:
             log.debug(f"FID.connect: unable to find DeviceID {self.device_id}")
             self.connecting = False
-            return SpectrometerResponse(data=False, poison_pill=True, error_msg=f"unable to find DeviceID {self.device_id}")
+            return SpectrometerResponse(data=False, error_msg=f"unable to find DeviceID {self.device_id}")
         else:
             log.debug("FID.connect: matched DeviceID %s", str(self.device_id))
 

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -151,7 +151,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 responses.append(SpectrometerResponse(error_msg="error processing cmd", error_lvl=ErrorLevel.medium))
         return responses
 
-    def connect(self) -> SpectrometerResponse:
+    def connect(self, retries=0) -> SpectrometerResponse:
         """
         Connect to the device and initialize basic settings.
         @warning this causes a problem in non-blocking mode (WasatchDeviceWrapper)
@@ -198,6 +198,11 @@ class FeatureIdentificationDevice(InterfaceDevice):
             log.debug("on MacOS, so NOT setting configuration and claiming interface")
         else:
             log.debug("on posix, so setting configuration and claiming interface")
+
+            # in the following, return SpectrometerResponse objects rather than 
+            # raising exceptions so the user will have a more-useful error 
+            # message to report or use in troubleshooting (exception still gets
+            # logged)
             try:
                 log.debug("setting configuration")
                 result = self.device_type.set_configuration(device)
@@ -206,22 +211,25 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 # This additional if statement is present for the Raspberry Pi. There is an issue with resource busy errors.
                 # Adding dev.reset() solves this. See https://stackoverflow.com/questions/29345325/raspberry-pyusb-gets-resource-busy
                 #####################################################################################################################
-                if "Resource busy" in str(exc):
+                if "Resource busy" in str(exc) and retries <= 3:
                     log.warn("Hardware Failure in setConfiguration. Resource busy error. Attempting to reattach driver by reset.")
                     self.device_type.reset(dev)
-                    connect() # MZ: I don't see how this could work?  What is connect()?
-                    return SpectrometerResponse(data=self.connected)
-                log.warn("Hardware Failure in setConfiguration", exc_info=1)
+                    sleep(10 ** retries) # 10^3 ms = 1sec max delay
+                    return self.connect(retries=retries+1) 
+
                 self.connecting = False
-                raise
+                msg = f"Hardware Failure in setConfiguration, giving up after {retries} retries"
+                log.critical(msg, exc_info=1)
+                return SpectrometerResponse(False, error_msg=msg)
 
             try:
                 log.debug("claiming interface")
                 result = self.device_type.claim_interface(device, 0)
             except Exception as exc:
-                log.warn("Hardware Failure in claimInterface", exc_info=1)
                 self.connecting = False
-                raise
+                msg = "Hardware Failure in claimInterface"
+                log.critical(msg, exc_info=1)
+                return SpectrometerResponse(False, error_msg=msg)
 
         self.device = device
 

--- a/wasatch/WrapperWorker.py
+++ b/wasatch/WrapperWorker.py
@@ -95,17 +95,17 @@ class WrapperWorker(threading.Thread):
             (ok,) = self.connected_device.handle_requests([req])
         except:
             log.critical("exception connecting", exc_info=1)
-            return self.settings_queue.put(None) # put(None, timeout=2)
+            return self.settings_queue.put_nowait(SpectrometerResponse(error_msg="exception while connecting"))
 
         if not ok.data:
             log.critical("failed to connect")
-            return self.settings_queue.put(None) # put(None, timeout=2)
+            return self.settings_queue.put_nowait(ok) 
 
         log.debug("successfully connected")
 
         # send the SpectrometerSettings back to the GUI thread
-        log.debug("returning SpectrometerSettings to parent")
-        self.settings_queue.put_nowait(self.connected_device.settings)
+        log.debug("returning SpectrometerSettings to parent via SpectrometerResponse")
+        self.settings_queue.put_nowait(SpectrometerResponse(self.connected_device.settings))
 
         log.debug("entering loop")
         last_command = datetime.datetime.now()


### PR DESCRIPTION
Passing SpectrometerResponse objects from connect() rather than bool/None