### PR TITLE
error msg for unprogrammed eeprom

### DIFF
--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -1,4 +1,3 @@
-from functools import reduce
 import subprocess
 import platform
 import datetime

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -1,3 +1,4 @@
+from functools import reduce
 import subprocess
 import platform
 import datetime
@@ -772,8 +773,13 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 log.error(msg)
                 return SpectrometerResponse(False, error_lvl=ErrorLevel.medium,error_msg=msg)
             buffers.append(buf)
-        flat_buffers_all_ones = [byte == 0xff for page in buffers for byte in page]
-        if all(flat_buffers_all_ones):
+
+        flat_buffers_all_ones = True
+        for page in buffers:
+            for byte in page:
+                flat_buffers_all_ones = flat_buffers_all_ones and (byte == 0xFF)
+
+        if flat_buffers_all_ones:
             return SpectrometerResponse(data=False,error_msg="Saw all Fs for EEPROM. Check EEPROM Programmed.",error_lvl=ErrorLevel.low)
         return SpectrometerResponse(data=self.settings.eeprom.parse(buffers))
 

--- a/wasatch/WrapperWorker.py
+++ b/wasatch/WrapperWorker.py
@@ -97,6 +97,8 @@ class WrapperWorker(threading.Thread):
             log.critical("exception connecting", exc_info=1)
             return self.settings_queue.put_nowait(SpectrometerResponse(error_msg="exception while connecting"))
 
+        log.debug(f"on connect request got results of {ok}")
+
         if not ok.data:
             log.critical("failed to connect")
             return self.settings_queue.put_nowait(ok) 


### PR DESCRIPTION
Ran into this error when Rich was trying to give us a demo. I recognize there was some discussion over roles here with WPSC for programming eeproms. This currently rejects the un-programmed spectrometer. I thought having the PR for discussion of if the desired behavior would instead be for it to connect and allow it to be written would be good. If we want to be able to connect to a spectrometer without any eeprom info, what would that look like?