### PR TITLE
forget disconnected devices

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2022-12-14 2.1.26
+    - forget disconnected USB devices
 - 2022-12-13 2.1.25
     - disable laserEnable verification loop for Series-XS
 - 2022-12-07 2.1.24

--- a/wasatch/WasatchBus.py
+++ b/wasatch/WasatchBus.py
@@ -22,10 +22,12 @@ class WasatchBus(object):
         self.usb_bus = USBBus()
         self.update()
 
-    ## called by Controller.update_connections
+    ## called by enlighten.Controller.tick_bus_listener()
     def update(self, poll = False):
         if self.usb_bus:
-            self.device_ids.extend(self.usb_bus.update(poll))
+            # MZ: if we call .extend here...when are devices ever purged from the stateful list?
+            # self.device_ids.extend(self.usb_bus.update(poll)) 
+            self.device_ids = self.usb_bus.update(poll)
             self.device_ids = list(set(self.device_ids)) # used in case of poll if same device is present before connection finishes
 
     def is_empty(self):


### PR DESCRIPTION
I'm not sure why we used to "extend" the WasatchUSB.device_list across calls to .update()...it made it impossible to ever watch an ejected spectrometer "disappear" from the list, because we never purged the list.