### PR TITLE
Default High-Gain Mode enabled on all InGaAs; forget disconnected devices.

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - 2022-12-14 2.1.26
+    - default InGaAs detectors to high-gain mode
     - forget disconnected USB devices
 - 2022-12-13 2.1.25
     - disable laserEnable verification loop for Series-XS

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2022-12-14 2.1.26
+    - forget disconnected USB devices
 - 2022-12-13 2.1.25
     - disable laserEnable verification loop for Series-XS
 - 2022-12-07 2.1.24

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -255,14 +255,11 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
         log.debug("model-specific settings")
 
-        if self.settings.is_ingaas():
-            # This must be for some very old InGaAs spectrometers?
-            # Will probably want to remove this for Series-XS...
-            if not self.settings.is_arm():
-                self.settings.eeprom.active_pixels_horizontal = 512
+        # models supporting high-gain mode
+        if self.settings.is_ingaas() or self.settings.is_andor():
 
-            if not self.get_high_gain_mode_enabled():
-                self.set_high_gain_mode_enable(True)
+            # default high for Raman
+            self.set_high_gain_mode_enable(self.settings.has_excitation())
 
         # ######################################################################
         # EEPROM

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -255,11 +255,9 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
         log.debug("model-specific settings")
 
-        # models supporting high-gain mode
-        if self.settings.is_ingaas() or self.settings.is_andor():
-
-            # default high for Raman
-            self.set_high_gain_mode_enable(self.settings.has_excitation())
+        # default high-gain mode for InGaAs
+        if self.settings.is_ingaas():
+            self.set_high_gain_mode_enable(True)
 
         # ######################################################################
         # EEPROM

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -423,7 +423,7 @@ class SpectrometerSettings(object):
         elif self.eeprom is None or self.eeprom.detector is None:
             log.debug("is_ingaas FALSE because missing EEPROM or detector")
             return False
-        elif re.match(r'ingaas|g9214|g9206|g14237', self.eeprom.detector.lower()):
+        elif re.match(r'ingaas|g9214|g9206|g14237|du490', self.eeprom.detector.lower()):
             log.debug("is_ingaas TRUE because detector")
             return True
         elif self.fpga_options is not None and self.fpga_options.has_cf_select:

--- a/wasatch/WasatchBus.py
+++ b/wasatch/WasatchBus.py
@@ -22,10 +22,12 @@ class WasatchBus(object):
         self.usb_bus = USBBus()
         self.update()
 
-    ## called by Controller.update_connections
+    ## called by enlighten.Controller.tick_bus_listener()
     def update(self, poll = False):
         if self.usb_bus:
-            self.device_ids.extend(self.usb_bus.update(poll))
+            # MZ: if we call .extend here...when are devices ever purged from the stateful list?
+            # self.device_ids.extend(self.usb_bus.update(poll)) 
+            self.device_ids = self.usb_bus.update(poll)
             self.device_ids = list(set(self.device_ids)) # used in case of poll if same device is present before connection finishes
 
     def is_empty(self):


### PR DESCRIPTION
Two changes here:

- by default, enable High-Gain Mode on all InGaAs detectors
- drop disconnected devices from WasatchUSB's internal device list, so that they can be "re-discovered" on reconnect