### PR TITLE
Adding support for 220250 Rev4A

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -4,6 +4,7 @@
     - XS-Series
         - added set_laser_power_attenuator
         - added support for startup laser TEC setpoint
+        - read battery @ 1Hz
 - 2023-07-10 2.1.32
     - offset gettors now return SpectrometerResponse 
     - fixed display of gettors returning SpectrometerResponse in WasatchShell 

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- 2023-??-?? 2.1.33
+    - XS-Series
+        - added set_laser_power_attenuator
+        - added support for startup laser TEC setpoint
 - 2023-07-10 2.1.32
     - offset gettors now return SpectrometerResponse 
     - fixed display of gettors returning SpectrometerResponse in WasatchShell 

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -4,7 +4,7 @@
     - XS-Series
         - added set_laser_power_attenuator
         - added support for startup laser TEC setpoint
-        - read battery @ 1Hz
+        - read battery @ 0.2Hz
 - 2023-07-10 2.1.32
     - offset gettors now return SpectrometerResponse 
     - fixed display of gettors returning SpectrometerResponse in WasatchShell 

--- a/WasatchShell/wasatch-shell.py
+++ b/WasatchShell/wasatch-shell.py
@@ -83,7 +83,7 @@ class WasatchShell(object):
             "get_integration_time_ms",                  # SR
             "get_lamp_enabled",                         # SR
             "get_laser_enabled",                        # SR
-            "get_laser_power_attenuation",              # SR
+            "get_laser_power_attenuator",               # SR
             "get_laser_interlock",                      # SR
             "get_laser_temperature_degC",               # SR
             "get_laser_temperature_raw",                # SR
@@ -139,7 +139,7 @@ class WasatchShell(object):
         set_laser_enable                       - takes bool argument (on/off, true/false, 1/0)
         set_laser_power_mw                     - takes float argument
         set_laser_power_perc                   - takes int argument
-        set_laser_power_attenuation            - takes uint8 argument
+        set_laser_power_attenuator             - takes uint8 argument
         set_laser_watchdog_sec                 - takes integer argument
         set_acquisition_laser_trigger_enable   - takes bool argument
         set_acquisition_laser_trigger_delay_ms - takes float argument
@@ -361,8 +361,8 @@ class WasatchShell(object):
                             self.device.change_setting("laser_power_perc", self.read_float())
                             self.display(1)
 
-                        elif command == "set_laser_power_attenuation":
-                            self.device.change_setting("laser_power_attenuation", self.read_int())
+                        elif command == "set_laser_power_attenuator":
+                            self.device.change_setting("laser_power_attenuator", self.read_int())
                             self.display(1)
 
                         elif command == "set_laser_enable":

--- a/WasatchShell/wasatch-shell.py
+++ b/WasatchShell/wasatch-shell.py
@@ -70,8 +70,8 @@ class WasatchShell(object):
             "get_dac",                                  # SR
             "get_detector_gain",                        # SR
             "get_detector_gain_odd",                    # SR
-            "get_detector_offset",                      # raw (now SR)
-            "get_detector_offset_odd",                  # raw (now SR)
+            "get_detector_offset",                      # SR
+            "get_detector_offset_odd",                  # SR
             "get_detector_tec_setpoint_degC",           # SR
             "get_detector_tec_setpoint_raw",            # SR
             "get_detector_temperature_degC",            # SR
@@ -83,6 +83,7 @@ class WasatchShell(object):
             "get_integration_time_ms",                  # SR
             "get_lamp_enabled",                         # SR
             "get_laser_enabled",                        # SR
+            "get_laser_power_attenuation",              # SR
             "get_laser_interlock",                      # SR
             "get_laser_temperature_degC",               # SR
             "get_laser_temperature_raw",                # SR
@@ -138,6 +139,7 @@ class WasatchShell(object):
         set_laser_enable                       - takes bool argument (on/off, true/false, 1/0)
         set_laser_power_mw                     - takes float argument
         set_laser_power_perc                   - takes int argument
+        set_laser_power_attenuation            - takes uint8 argument
         set_laser_watchdog_sec                 - takes integer argument
         set_acquisition_laser_trigger_enable   - takes bool argument
         set_acquisition_laser_trigger_delay_ms - takes float argument
@@ -357,6 +359,10 @@ class WasatchShell(object):
 
                         elif command == "set_laser_power_perc":
                             self.device.change_setting("laser_power_perc", self.read_float())
+                            self.display(1)
+
+                        elif command == "set_laser_power_attenuation":
+                            self.device.change_setting("laser_power_attenuation", self.read_int())
                             self.display(1)
 
                         elif command == "set_laser_enable":

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -42,7 +42,7 @@ class EEPROM(object):
         self.model                       = None
         self.serial_number               = None
         self.baud_rate                   = 0
-        self.has_cooling                 = False
+        self.has_cooling                 = False    # explicitly means detector TEC, not laser
         self.has_battery                 = False
         self.has_laser                   = False
         self.feature_mask                = 0

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -58,7 +58,7 @@ class EEPROM(object):
         self.excitation_nm_float         = 0.0
         self.slit_size_um                = 0
         self.startup_integration_time_ms = 10
-        self.startup_temp_degC           = 15
+        self.startup_temp_degC           = 15       # normally used for detector TEC; now also used for raw laser TEC on SiG (needs updated in ENG-0034)
         self.startup_triggering_scheme   = 0
         self.detector_gain               = 1.9
         self.detector_offset             = 0

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -282,14 +282,20 @@ class FeatureIdentificationDevice(InterfaceDevice):
         # TEC Setpoint
         # ######################################################################
 
-        if self.settings.eeprom.has_cooling:
-
-            if self.settings.is_xs() and self.settings.eeprom.sig_laser_tec:
-                log.debug("XS with cooling, so using TEC setpoint for laser")
+        if self.settings.is_xs():
+            
+            # XS only supports a TEC on the laser, not the detector
+            if self.settings.eeprom.sig_laser_tec:
+                log.debug("initializing laser TEC on XS")
                 self.set_laser_temperature_setpoint_raw(self.settings.eeprom.startup_temp_degC)
 
-            else:
-                # FX2 / Hamamatsu-based, so assume TEC setpoint is for detector
+        else:
+            
+            # X/XM models don't require runtime configuration of the laser TEC
+            # (it's set via pots on 110280 (SML) or 110613 (MML)), but do need
+            # to initialize the detector TEC for R and C units.
+            if self.settings.eeprom.has_cooling:
+
                 degC = None
                 eeprom = self.settings.eeprom
 

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -299,7 +299,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 degC = None
                 eeprom = self.settings.eeprom
 
-                if eeprom.min_temp_degC <= startup_temp_degC <= eeprom.max_temp_degC:
+                if eeprom.min_temp_degC <= eeprom.startup_temp_degC <= eeprom.max_temp_degC:
                     degC = eeprom.startup_temp_degC
                 elif re.match(r"7031|10141|9214", eeprom.detector):
                     degC = -15

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -832,14 +832,14 @@ class FeatureIdentificationDevice(InterfaceDevice):
     def get_battery_state_raw(self): # -> SpectrometerResponse 
         """Retrieves the raw battery reading and then caches it for 1 sec"""
         now = datetime.datetime.now()
-        if (self.settings.state.battery_timestamp is not None and now < self.settings.state.battery_timestamp + datetime.timedelta(seconds=1)):
+        if self.settings.state.battery_timestamp is not None and (now - self.settings.state.battery_timestamp).total_seconds() < 1:
             return SpectrometerResponse(data=self.settings.state.battery_raw)
 
         self.settings.state.battery_timestamp = now
         response = self.get_upper_code(0x13, label="GET_BATTERY_STATE", msb_len=3)
         self.settings.state.battery_raw = response.data
 
-        log.debug("battery_state_raw: {self.settings.state.battery_raw}")
+        log.debug(f"battery_state_raw: 0x{self.settings.state.battery_raw:04x}")
         return SpectrometerResponse(data=self.settings.state.battery_raw)
 
     def get_battery_percentage(self): # -> SpectrometerResponse 

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -284,8 +284,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
         if self.settings.eeprom.has_cooling:
 
-            if self.settings.is_xs():
-                log.debug("XS with cooling, so assuming TEC setpoint is for laser")
+            if self.settings.is_xs() and self.settings.eeprom.sig_laser_tec:
+                log.debug("XS with cooling, so using TEC setpoint for laser")
                 self.set_laser_temperature_setpoint_raw(self.settings.eeprom.startup_temp_degC)
 
             else:

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -198,6 +198,7 @@ class SpectrometerSettings(object):
         degC = None
         if   "11511" in det: degC =  10
         elif "16011" in det: degC =  10
+        elif "13971" in det: degC =  10
         elif "10141" in det: degC = -15
         elif "9214"  in det: degC = -15
         elif "7031"  in det: degC = -15

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -185,11 +185,8 @@ class SpectrometerSettings(object):
             return (self.eeprom.roi_vertical_region_1_start,
                     self.eeprom.roi_vertical_region_1_end)
 
-    ##
-    # @note S11510 is ambient so shouldn't have a TEC
     def default_detector_setpoint_degC(self):
-        log.debug("default_detector_setpoint_degC: here")
-
+        
         # newer units should specify this via EEPROM
         if self.eeprom.format >= 4:
             log.debug("default_detector_setpoint_degC: eeprom.format %d so using startup_temp_degC %d",
@@ -199,14 +196,14 @@ class SpectrometerSettings(object):
         # otherwise infer from detector
         det = self.eeprom.detector.upper()
         degC = None
-        if   "S11511" in det: degC =  10
-        elif "S10141" in det: degC = -15
-        elif "G9214"  in det: degC = -15
-        elif "7031"   in det: degC = -15
+        if   "11511" in det: degC =  10
+        elif "16011" in det: degC =  10
+        elif "10141" in det: degC = -15
+        elif "9214"  in det: degC = -15
+        elif "7031"  in det: degC = -15
 
         if degC is not None:
-            log.debug("default_detector_setpoint_degC: defaulting to %d per supported detector %s",
-                degC, det)
+            log.debug("default_detector_setpoint_degC: defaulting to %d per supported detector %s", degC, det)
             return degC
 
         log.error("default_detector_setpoint_degC: serial %s has unknown detector %s",

--- a/wasatch/WasatchDevice.py
+++ b/wasatch/WasatchDevice.py
@@ -472,9 +472,9 @@ class WasatchDevice(InterfaceDevice):
             except Exception as exc:
                 log.debug("Error reading ambient temperature", exc_info=1)
 
-        # read battery every 10sec
+        # read battery every 1sec
         if self.settings.eeprom.has_battery:
-            if self.settings.state.battery_timestamp is None or (datetime.datetime.now() >= self.settings.state.battery_timestamp + datetime.timedelta(seconds=10)):
+            if self.settings.state.battery_timestamp is None or (datetime.datetime.now() >= self.settings.state.battery_timestamp + datetime.timedelta(seconds=1)):
                 req = SpectrometerRequest("get_battery_state_raw")
                 res = self.hardware.handle_requests([req])[0]
                 if res.error_msg != '':

--- a/wasatch/WasatchDevice.py
+++ b/wasatch/WasatchDevice.py
@@ -472,9 +472,12 @@ class WasatchDevice(InterfaceDevice):
             except Exception as exc:
                 log.debug("Error reading ambient temperature", exc_info=1)
 
-        # read battery every 1sec
+        # read battery every 5sec
         if self.settings.eeprom.has_battery:
-            if self.settings.state.battery_timestamp is None or (datetime.datetime.now() >= self.settings.state.battery_timestamp + datetime.timedelta(seconds=1)):
+            if self.settings.state.battery_timestamp is None or (datetime.datetime.now() - self.settings.state.battery_timestamp).total_seconds() > 5:
+
+                # note that the following 3 requests should actually only generate 
+                # one USB transaction as raw is cached internally
                 req = SpectrometerRequest("get_battery_state_raw")
                 res = self.hardware.handle_requests([req])[0]
                 if res.error_msg != '':
@@ -506,7 +509,7 @@ class WasatchDevice(InterfaceDevice):
                     acquire_response.poison_pill = True
                     return acquire_response
 
-                log.debug("battery: level %.2f%% (%s)", reading.battery_percentage, "charging" if reading.battery_charging else "not charging")
+                log.debug("battery: %.2f%% (%s)", reading.battery_percentage, "charging" if reading.battery_charging else "discharging")
             else:
                 if reading is not None:
                     reading.battery_percentage = self.last_battery_percentage


### PR DESCRIPTION
- adds get/set_laser_power_attenuator (new feature on Rev4A boards)
- automatically reads configured laser TEC setpoint from EEPROM and applies to the board on connection
- tweaks to battery read-out
- minor cleanup