### PR TITLE
Enforce FPGA version length

### DIFF
--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -193,6 +193,16 @@ class EEPROM(object):
         self.buffers = buffers
         self.digest = self.generate_digest()
 
+        # handy for debugs
+        self.hexbuf = [" ".join([f"{v:02x}" for v in buf]) for buf in buffers]
+
+        # check for known ne'er-do-well
+        bad = r"c2 47 05 31 21 00 00 04 00 03 00 00 02 31 a5 00 03 00 33 02 39 0f 00 03 00 43 02 2f 00 00 03 00 " \
+            + r"4b 02 2b 23 00 03 00 53 02 2f 00 03 ff 01 00 90 e6 78 e0 54 10 ff c4 54 0f 44 50 f5 09 13 e4"
+        for i, s in enumerate(self.hexbuf):
+            if bad in s:
+                log.error(f"bad string found in EEPROM page {i}")
+
         # unpack all the fields we know about
         try:
             self.read_eeprom()

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -735,8 +735,9 @@ class FeatureIdentificationDevice(InterfaceDevice):
             self._schedule_disconnect(exc)
             return SpectrometerResponse(poison_pill=True)
 
+        result_hex = " ".join([f"{v:02x}" for v in result])
         log.debug("%s_get_code: request 0x%02x value 0x%04x index 0x%04x = [%s]",
-            prefix, bRequest, wValue, wIndex, result)
+            prefix, bRequest, wValue, wIndex, result_hex)
 
         if result is None:
             log.critical("_get_code[%s, %s]: received null", label, self.device_id)

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -1026,7 +1026,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
     def get_fpga_firmware_version(self): # -> SpectrometerResponse 
         s = ""
-        res = self._get_code(0xb4, label="GET_FPGA_REV")
+        res = self._get_code(0xb4, wLength=7, label="GET_FPGA_REV")
         result = res.data
         if result is not None:
             for i in range(len(result)):


### PR DESCRIPTION
- enforce FPGA version length (exactly 7 bytes per API)
- log USB transfers in hex for readability
- built-in check for known-bad EEPROM string