### PR TITLE
allow limiting filesize for log append

### DIFF
--- a/wasatch/applog.py
+++ b/wasatch/applog.py
@@ -131,7 +131,7 @@ class MainLogger(object):
         if append_arg.lower() == "false":
             # when append is a falsy value, the log file is always reset on reboot
             append = False
-        if append_arg.lower() == "limit_20mb":
+        if append_arg.lower() == "limit":
             # the default --log-append keeps up to 20mb between sessions
             append = 20*1024*1024
 
@@ -150,8 +150,11 @@ class MainLogger(object):
         else:
             pathname = get_location()
 
-        if append:
-            utils.resize_file(path=pathname, nbytes=append)
+        try:
+            if append:
+                utils.resize_file(path=pathname, nbytes=append)
+        except (IOError, FileNotFoundError):
+            print("Unable to truncate log file.")
 
         root_logger = logging.getLogger()
         fh = logging.FileHandler(pathname, mode='a' if append else 'w', encoding='utf-8') 

--- a/wasatch/applog.py
+++ b/wasatch/applog.py
@@ -127,7 +127,7 @@ class MainLogger(object):
         # append file size limits are enforced upon program restart
         if append_arg.lower() == "true":
             # limit to 300mb if --log-append is explicitly set to "True"
-            append = 300*1024*1024
+            append = True
         if append_arg.lower() == "false":
             # when append is a falsy value, the log file is always reset on reboot
             append = False
@@ -151,7 +151,7 @@ class MainLogger(object):
             pathname = get_location()
 
         try:
-            if append:
+            if type(append) == int:
                 utils.resize_file(path=pathname, nbytes=append)
         except (IOError, FileNotFoundError):
             print("Unable to truncate log file.")

--- a/wasatch/applog.py
+++ b/wasatch/applog.py
@@ -114,7 +114,7 @@ class MainLogger(object):
             enable_stdout=True,
             logfile=None,
             timeout_sec=5,
-            append_arg):
+            append_arg="True"):
         self.log_queue     = Queue() 
         self.log_level     = log_level
         self.enable_stdout = enable_stdout

--- a/wasatch/applog.py
+++ b/wasatch/applog.py
@@ -24,6 +24,7 @@ import logging
 import platform
 import traceback
 import multiprocessing
+from . import utils
 from queue import Queue
 
 # ##############################################################################
@@ -113,7 +114,7 @@ class MainLogger(object):
             enable_stdout=True,
             logfile=None,
             timeout_sec=5,
-            append=False):
+            append_arg):
         self.log_queue     = Queue() 
         self.log_level     = log_level
         self.enable_stdout = enable_stdout
@@ -122,6 +123,17 @@ class MainLogger(object):
 
         if self.logfile is not None:
             set_location(self.logfile)
+
+        # append file size limits are enforced upon program restart
+        if append_arg.lower() == "true":
+            # limit to 300mb if --log-append is explicitly set to "True"
+            append = 300*1024*1024
+        if append_arg.lower() == "false":
+            # when append is a falsy value, the log file is always reset on reboot
+            append = False
+        if append_arg.lower() == "limit_20mb":
+            # the default --log-append keeps up to 20mb between sessions
+            append = 20*1024*1024
 
         root_log = logging.getLogger()
         self.log_configurer(self.logfile, append)
@@ -137,6 +149,9 @@ class MainLogger(object):
             pathname = self.logfile
         else:
             pathname = get_location()
+
+        if append:
+            utils.resize_file(path=pathname, nbytes=append)
 
         root_logger = logging.getLogger()
         fh = logging.FileHandler(pathname, mode='a' if append else 'w', encoding='utf-8') 

--- a/wasatch/utils.py
+++ b/wasatch/utils.py
@@ -4,14 +4,18 @@
 #                                                                              #
 # ##############################################################################
 
-import datetime
-import logging
-import ctypes
 import numpy
-import json
 import math
-import os
+
+import json
 import re
+
+import os
+import shutil
+import logging
+
+import datetime
+import ctypes
 
 log = logging.getLogger(__name__)
 
@@ -588,3 +592,79 @@ def uint16_to_little_endian(values):
         a.append(n & 0xff)          # lsb
         a.append((n >> 8) & 0xff)   # msb
     return a
+
+def resize_file(path, nbytes):
+    """
+    Keep only the last `nbytes` of a text file specified by `path`.
+
+    This function is encoding (utf-8, utf-16, ascii) agnostic because it uses the line-
+    continuation character '\n' as a boundary. It is system independent because it slices
+    before that character. This was written to keep our default log file within a reasonable
+    filesize, suitable for emailing.
+
+    Call this on a file that is not yet opened. Expect the file to be closed and flushed
+    by the time the function returns.
+
+    returns True if the file was changed.
+    """
+
+    # limit how much memory is used to copy file contents
+    MAX_BYTES_MEMORY = 2_000_000
+
+    START_OF_STREAM = 0 # seek from start of a file
+    CURRENT_STREAM = 1 # seek from current location in file
+    END_OF_STREAM = 2 # seek from end of file, offset should be negative
+
+    # open file with the intention of reading bytes, preserving what's there
+    f = open(path, "rb")
+
+    # path to temporary file
+    tpath = path+".temp"
+
+    # don't overwrite any local files
+    while os.path.exists(tpath):
+        tpath += ".temp"
+
+    f2 = open(tpath, "wb")
+
+    # fast-forward to end of file and keep track of total_bytes
+    tbytes = f.seek(0, END_OF_STREAM)
+
+    if tbytes <= nbytes:
+        # don't do anything if file is already smaller than target size
+        os.remove(tpath)
+        return False
+
+    # go to nbytes from the end
+    f.seek(-nbytes, END_OF_STREAM)
+
+    # seek to a newline
+    for i in range(500):
+        if f.read(1) == b'\n':
+            break
+
+    # make sure to land before the newline
+    t_start = f.seek(-1, CURRENT_STREAM)
+
+    # decrease nbytes by the amount we skipped forward (usually small)
+    nbytes = tbytes-t_start
+
+    # copy the end of the file into the beginning of a temporary one
+    f.seek(t_start, START_OF_STREAM)
+    i = nbytes
+    while i:
+        block_size = min(MAX_BYTES_MEMORY, i)
+
+        b = f.read(block_size)
+        f2.write(b)
+        i -= block_size
+
+    # wrap up resource use
+    f.close()
+    f2.flush()
+    f2.close()
+
+    # move temporary file in place
+    shutil.move(tpath, path)
+
+    return True

--- a/wasatch/utils.py
+++ b/wasatch/utils.py
@@ -593,7 +593,7 @@ def uint16_to_little_endian(values):
         a.append((n >> 8) & 0xff)   # msb
     return a
 
-def resize_file(path, nbytes):
+def resize_file(path, nbytes, ensure_no_overwrite=False):
     """
     Keep only the last `nbytes` of a text file specified by `path`.
 
@@ -622,8 +622,10 @@ def resize_file(path, nbytes):
     tpath = path+".temp"
 
     # don't overwrite any local files
-    while os.path.exists(tpath):
-        tpath += ".temp"
+    # defaults to false so we don't err on the side of a bunch of extra .temp files
+    if ensure_no_overwrite:
+        while os.path.exists(tpath):
+            tpath += ".temp"
 
     f2 = open(tpath, "wb")
 
@@ -632,6 +634,7 @@ def resize_file(path, nbytes):
 
     if tbytes <= nbytes:
         # don't do anything if file is already smaller than target size
+        f2.close()
         os.remove(tpath)
         return False
 


### PR DESCRIPTION
On program start if the logfile is more than 20mb then it will be trimmed to that size.
This coincides with making append the default log behavior in Enlighten.

Very often when Enlighten fails, users will try to restart, then they'll email us. In this case the log file that corresponds to their failing session is lost. Now it will be truncated to an email-able size <25mb. 

Notice that this applies to the `~/EnlightenSpectra/enlighten.log` file, not the file that is used by `run.bat` by a development session. Development sessions will also check on the `~/EnlightenSpectra/enlighten.log` file and clamp it on start.

Log file filled up (artificially)
<img width="743" alt="image" src="https://github.com/WasatchPhotonics/Wasatch.PY/assets/124081765/553ab176-a74b-48e1-bcb6-bd44cfa575d6">

Log file size reduced instantaneously on start
<img width="740" alt="image" src="https://github.com/WasatchPhotonics/Wasatch.PY/assets/124081765/64e3dd0c-6ad8-4f50-9920-94b4eb836a31">

However when the log file is as big as 20mb, post truncate, ResourceMonitorFeature hangs for 1m15s - we may want to reduce the max log size even more. 

I still don't know how many hours of program time corresponds to this size. It would be great if we can figure out the size that corresponds to roughly 10 hours of program time.
 