### PR TITLE
Disable SPI functionality until reason/opportunity to investigate

### DIFF
--- a/wasatch/SPIDevice.py
+++ b/wasatch/SPIDevice.py
@@ -13,8 +13,12 @@ from typing import Callable, Any
 # Device Finder should already have done this
 # For thoroughness though doing here anyway
 # This is required for finding the usb <-> serial board
-import usb.core
-usb.core.find()
+#
+# MZ: I don't remember anything about this, but SPI is not a priority at
+#     this time and this broke under Python 3.11
+#
+# import usb.core
+# usb.core.find()
 
 from .SpectrometerSettings        import SpectrometerSettings
 from .SpectrometerState           import SpectrometerState

--- a/wasatch/SPIDevice.py
+++ b/wasatch/SPIDevice.py
@@ -17,7 +17,7 @@ from typing import Callable, Any
 # MZ: I don't remember anything about this, but SPI is not a priority at
 #     this time and this broke under Python 3.11
 #
-# import usb.core
+import usb.core
 # usb.core.find()
 
 from .SpectrometerSettings        import SpectrometerSettings


### PR DESCRIPTION
We don't actually have any SPI boards to test with at the moment, and this API hadn't been working well anyway.