### PR TITLE
support horizontal ROI for XL virtual EEPROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2024-05-24 2.1.68
+    - added horizontal ROI to XL virtual EEPROM
 - 2024-05-22 2.1.67
     - relax thread logging 10sec after successful connection
     - display connected spectrometer properties in demo.py

--- a/wasatch/AndorDevice.py
+++ b/wasatch/AndorDevice.py
@@ -472,6 +472,8 @@ class AndorDevice(InterfaceDevice):
                    'invert_x_axis',
                    'wavelength_coeffs', 
                    'excitation_nm_float',
+                   'roi_horizontal_end',
+                   'roi_horizontal_start',
                    'raman_intensity_coeffs',
                    'raman_intensity_calibration_order',
                    'startup_temp_degC', 

--- a/wasatch/__init__.py
+++ b/wasatch/__init__.py
@@ -1,4 +1,4 @@
 """This package is a driver for Wasatch Photonics spectrometers"""
 
-__version__ = "2.1.67"  # This is used by flit and other pypi things
+__version__ = "2.1.68"  # This is used by flit and other pypi things
 version = __version__   # This is to avoid breaking other files that originally used .version instead of __version__


### PR DESCRIPTION
- added roi_horizontal_start/end to wasatch.AndorDevice
- tested with 532XL with SRM calibration