### PR TITLE
Adding subformat 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+- 2024-11-25 2.2.14
+    - EEPROM
+        - added subformat 5 (EEPROM.MultiWavelengthCalibration)
+        - bumped rev to 17
+        - deprecated subformat 4 (regions)
+    - SpectrometerSettings
+        - deprecated integer excitation_nm
+        - moved vertical ROI to wasatch.ROI
+        - added calibrations(), select_calibration(n)
+    - FeatureInterfaceDevice
+        - added set/get_scans_to_average
+    - SpectrometerState
+        - added onboard_averaging
 - 2024-11-01 2.2.13
     - support for InGaAs linear pixel calibration
     - re-enable STM32 serial number

--- a/wasatch/AutoRamanRequest.py
+++ b/wasatch/AutoRamanRequest.py
@@ -74,3 +74,23 @@ class AutoRamanRequest:
         buf.extend([self.saturation       & 0xff, (self.saturation    >> 8) & 0xff])
         buf.extend([self.max_avg          & 0xff                                  ]) 
         return buf
+
+if __name__ == "__main__":
+    aar = AutoRamanRequest(
+        max_ms         = 10000,
+        start_integ_ms = 100,
+        start_gain_db  = 0,
+        max_integ_ms   = 2000,
+        min_integ_ms   = 10,
+        max_gain_db    = 32,
+        min_gain_db    = 0,
+        target_counts  = 45000,
+        max_counts     = 50000,
+        min_counts     = 40000,
+        max_factor     = 5,
+        drop_factor    = 0.8,
+        saturation     = 65000,
+        max_avg        = 100)
+
+    buf = aar.serialize()
+    print("0x" + " ".join([f"{b:02x}" for b in buf]))

--- a/wasatch/DeviceFinderUSB.py
+++ b/wasatch/DeviceFinderUSB.py
@@ -161,14 +161,14 @@ class DeviceFinderUSB:
         return [DeviceID(device) for device in pyusb_devices]
 
     def find_usb_devices(self, poll = False):
-        log.debug("DeviceFinderUSB.find_usb_devices: starting")
+        # log.debug("DeviceFinderUSB.find_usb_devices: starting")
         device_ids = []
 
         # MZ/ED: If USE_MONITORING is True, I had to disable the call to remove_all in enlighten.Controller
         if self.startup_scan < self.MIN_POLLING_SCANS or not self.USE_MONITORING or poll:
             # our first few scans should always be a bus poll
             # this is because no events will be registered
-            log.debug(f"DeviceFinderUSB.find_usb_devices: just doing a bus poll for startup_scan {self.startup_scan}")
+            # log.debug(f"DeviceFinderUSB.find_usb_devices: just doing a bus poll for startup_scan {self.startup_scan}")
             device_ids = self.bus_polling()
             self.startup_scan += 1
         elif platform.system() == "Windows":
@@ -177,7 +177,7 @@ class DeviceFinderUSB:
             device_ids = self.linux_monitoring()
         else:
             device_ids = self.bus_polling()
-        log.debug(f"DeviceFinderUSB.find_usb_devices: returning {len(device_ids)} devices")
+        # log.debug(f"DeviceFinderUSB.find_usb_devices: returning {len(device_ids)} devices")
         return device_ids
 
     def mac_monitoring(self):

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -927,18 +927,6 @@ class EEPROM:
         if 0 <= start and start < end and end < self.active_pixels_horizontal:
             return ROI(start, end)
 
-    def get_vertical_roi(self):
-        n = self.multi_wavelength_calibration.selected_calibration + 1
-
-        start = getattr(self, f"roi_vertical_region_{n}_start")
-        end   = getattr(self, f"roi_vertical_region_{n}_end")
-
-        if start > end:
-            end, start = start, end
-
-        if 0 <= start and start < end and end < self.active_pixels_vertical:
-            return ROI(start, end)
-
     ## 
     # On a 1024-pixel detector, note the expected / correct result based on the 
     # roi_horizontal_start/stop fields:
@@ -1214,8 +1202,8 @@ class MultiWavelengthCalibration:
         if calibration is None:
             calibration = self.selected_calibration
         if calibration >= len(a):
-            log.warn(f"MultiWavelengthCalibration.get: returning {label} 0 because calibration {calibration} not in array len {len(a)}")
-            return 0
+            log.warn(f"MultiWavelengthCalibration.get: returning default {default} because calibration {calibration} not in {label} array len {len(a)}")
+            return default
 
         if index is None:
             value = a[calibration] 

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -528,9 +528,10 @@ class EEPROM:
         # Page 1
         # ######################################################################
 
-        if self.wavelength_coeffs is not None:
-            for i in range(min(4, len(self.wavelength_coeffs))):
-                self.pack((1,  0 + i * 4,  4), "f", self.wavelength_coeffs[i])
+        wavelength_coeffs = self.multi_wavelength_calibration.get("wavelength_coeffs")
+        if wavelength_coeffs is not None:
+            for i in range(min(4, len(wavelength_coeffs))):
+                self.pack((1,  0 + i * 4,  4), "f", wavelength_coeffs[i])
                 
         if self.degC_to_dac_coeffs is not None:
             for i in range(min(3, len(self.degC_to_dac_coeffs))):
@@ -560,12 +561,12 @@ class EEPROM:
             self.pack((2, 23,  2), "H", max(0xffff, self.max_integration_time_ms))
         else:
             coeff = 0.0
-            if len(self.wavelength_coeffs) > 4:
-                coeff = self.wavelength_coeffs[4]
+            if len(wavelength_coeffs) > 4:
+                coeff = wavelength_coeffs[4]
             self.pack((2, 21,  4), "f", coeff)
         self.pack((2, 25,  2), "H", self.actual_pixels_horizontal)
-        self.pack((2, 27,  2), "H", self.roi_horizontal_start)
-        self.pack((2, 29,  2), "H", self.roi_horizontal_end)
+        self.pack((2, 27,  2), "H", self.multi_wavelength_calibration.get("roi_horizontal_start"))
+        self.pack((2, 29,  2), "H", self.multi_wavelength_calibration.get("roi_horizontal_end"))
         self.pack((2, 31,  2), "H", self.roi_vertical_region_1_start)
         self.pack((2, 33,  2), "H", self.roi_vertical_region_1_end)
         self.pack((2, 35,  2), "H", self.roi_vertical_region_2_start)
@@ -587,15 +588,15 @@ class EEPROM:
 
         self.pack((3, 28,  4), "f", self.max_laser_power_mW)
         self.pack((3, 32,  4), "f", self.min_laser_power_mW)
-        self.pack((3, 36,  4), "f", self.excitation_nm_float)
+        self.pack((3, 36,  4), "f", self.multi_wavelength_calibration.get("excitation_nm_float"))
         self.pack((3, 40,  4), "I", self.min_integration_time_ms)
         self.pack((3, 44,  4), "I", self.max_integration_time_ms)
-        self.pack((3, 48,  4), "f", self.avg_resolution)
+        self.pack((3, 48,  4), "f", self.multi_wavelength_calibration.get("avg_resolution"))
         self.pack((3, 52,  2), "H", self.laser_watchdog_sec)
         self.pack((3, 54,  1), "B", self.light_source_type)
         self.pack((3, 55,  2), "H", self.power_timeout_sec)
         self.pack((3, 57,  2), "H", self.detector_timeout_sec)
-        self.pack((3, 59,  1), "B", self.horiz_binning_mode)
+        self.pack((3, 59,  1), "B", self.multi_wavelength_calibration.get("horiz_binning_mode"))
 
         # ######################################################################
         # Page 4
@@ -849,14 +850,13 @@ class EEPROM:
         log.debug("  Shutter:          %s", self.has_shutter)
         log.debug("  Disable BLE Power:%s", self.disable_ble_power)
         log.debug("  Dis Laser Arm Ind:%s", self.disable_laser_armed_indicator)
-        log.debug("  Excitation:       %s nm", self.excitation_nm)
-        log.debug("  Excitation (f):   %.2f nm", self.excitation_nm_float)
+        log.debug("  Excitation (f):   %.2f nm", self.multi_wavelength_calibration.get("excitation_nm_float"))
         log.debug("  Laser Warmup Sec: %d", self.laser_warmup_sec)
         log.debug("  Laser Watchdog:   %d", self.laser_watchdog_sec)
         log.debug("  Light Source:     %d", self.light_source_type)
         log.debug("  Power Timeout:    %d", self.power_timeout_sec)
         log.debug("  Detector Timeout: %d", self.detector_timeout_sec)
-        log.debug("  Horiz Bin Mode:   %d", self.horiz_binning_mode)
+        log.debug("  Horiz Bin Mode:   %d", self.multi_wavelength_calibration.get("horiz_binning_mode"))
         log.debug("  Slit size:        %s um", self.slit_size_um)
         log.debug("  Start Integ Time: %d ms", self.startup_integration_time_ms)
         log.debug("  Start Temp:       %.2f degC", self.startup_temp_degC)
@@ -867,7 +867,7 @@ class EEPROM:
         log.debug("  Det Offset Odd:   %d", self.detector_offset_odd)
         log.debug("  Start Laser TEC:  %d (raw)", self.startup_laser_tec_setpoint)
         log.debug("")
-        log.debug("  Wavecal coeffs:   %s", self.wavelength_coeffs)
+        log.debug("  Wavecal coeffs:   %s", self.multi_wavelength_calibration.get("wavelength_coeffs"))
         log.debug("  degCToDAC coeffs: %s", self.degC_to_dac_coeffs)
         log.debug("  adcToDegC coeffs: %s", self.adc_to_degC_coeffs)
         log.debug("  Det temp max:     %s degC", self.max_temp_degC)
@@ -884,8 +884,8 @@ class EEPROM:
         log.debug("  Actual Px Vert:   %d", self.actual_pixels_vertical)
         log.debug("  Min integration:  %d ms", self.min_integration_time_ms)
         log.debug("  Max integration:  %d ms", self.max_integration_time_ms)
-        log.debug("  ROI Horiz Start:  %d", self.roi_horizontal_start)
-        log.debug("  ROI Horiz End:    %d", self.roi_horizontal_end)
+        log.debug("  ROI Horiz Start:  %d", self.multi_wavelength_calibration.get("roi_horizontal_start"))
+        log.debug("  ROI Horiz End:    %d", self.multi_wavelength_calibration.get("roi_horizontal_end"))
         log.debug("  ROI Vert Reg 1:   (%d, %d)", self.roi_vertical_region_1_start, self.roi_vertical_region_1_end)
         log.debug("  ROI Vert Reg 2:   (%d, %d)", self.roi_vertical_region_2_start, self.roi_vertical_region_2_end)
         log.debug("  ROI Vert Reg 3:   (%d, %d)", self.roi_vertical_region_3_start, self.roi_vertical_region_3_end)
@@ -894,7 +894,7 @@ class EEPROM:
         log.debug("  Laser coeffs:     %s", self.laser_power_coeffs)
         log.debug("  Max Laser Power:  %s mW", self.max_laser_power_mW)
         log.debug("  Min Laser Power:  %s mW", self.min_laser_power_mW)
-        log.debug("  Avg Resolution:   %.2f", self.avg_resolution)
+        log.debug("  Avg Resolution:   %.2f", self.multi_wavelength_calibration.get("avg_resolution"))
         log.debug("")
         log.debug("  User Text:        %s", self.user_text)
         log.debug("")
@@ -1180,6 +1180,7 @@ class MultiWavelengthCalibration:
                             'avg_resolution', 'raman_intensity_coeffs', 
                             'horiz_binning_mode' ]
         self.values = {}
+        self.calibrations = 1
         self.selected_calibration = 0 # e.g., self.values['avg_resolution'][selected_calibration]
 
     def is_multi_wavelength(self, name):
@@ -1226,14 +1227,24 @@ class MultiWavelengthCalibration:
             a = self.values[name]
             if calibration is None:
                 calibration = self.selected_calibration
+
             while len(a) - 1 < calibration:
                 a.append(0)
+
+            if self.calibrations < calibration + 1:
+                self.calibrations = calibration + 1
+
             if index is None:
                 label = f"{name}[{calibration}]"
                 a[calibration] = value
+                if calibration == 0:
+                    setattr(self.eeprom, name, value)
             else:
                 label = f"{name}[{calibration}][{index}]"
                 a[calibration][index] = value
+                if calibration == 0:
+                    setattr(self.eeprom, name, a[calibration])
+
             log.debug(f"MultiWavelengthCalibration.set: set {label} = {value}")
         except:
             log.error(f"MultiWavelengthCalibration.set: failed to set name {name}, calibration {calibration}, index {index}, value {value}", exc_info=1)
@@ -1242,6 +1253,9 @@ class MultiWavelengthCalibration:
         if calibration < 1:
             # assume calibration[0] was read with standard eeprom.read
             return
+
+        if self.calibrations < calibration + 1:
+            self.calibrations = calibration + 1
 
         page = 6 + calibration
         log.debug(f"MultiWavelengthCalibration.read: reading calibration {calibration} from page {page}")
@@ -1254,11 +1268,10 @@ class MultiWavelengthCalibration:
         self.values["raman_intensity_coeffs" ].append([ self.eeprom.unpack((page, 34 + i * 4,  4), "f") for i in range(6) ])
 
     def write(self):
-        calibrations = len(self.values["excitation_nm_float"])
-        log.debug(f"MultiWavelengthCalibration.write: found {calibrations} calibrations")
+        log.debug(f"MultiWavelengthCalibration.write: calibrations {self.calibrations}")
 
         # assume calibration[0] output with standard eeprom.write
-        for calibration in range(1, calibrations):
+        for calibration in range(1, self.calibrations):
             page = 6 + calibration
             log.debug(f"MultiWavelengthCalibration.write: writing calibration {calibration} to page {page}")
 
@@ -1272,9 +1285,10 @@ class MultiWavelengthCalibration:
 
     def dump(self):
         log.debug("Multi-Wavelength:")
-        for name in self.attributes:
-            for i in range(len(self.values[name])):
-                log.debug("  #{i} {name} = {self.values[name][i]}")
+        for i in range(self.calibrations):
+            log.debug(f"  Calibration #{i}")
+            for name in self.attributes:
+                log.debug(f"    {name} = {self.get(name, calibration=i)}")
 
     def toJSON(self): 
         return str(self.__dict__)

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -1170,6 +1170,43 @@ class MultiWavelengthCalibration:
     wavelength calibration, horizontal ROI, Raman Intensity Calibration, 
     average resolution, and horizontal binning mode. (Vertical ROI was 
     presciently covered in Format 1.)
+
+    @par Theory of Operation
+
+    A "calibration" is one set of attributes (self.attributes) related to
+    a particular grating region.
+
+    Most of this class architecture could conceivably support many different
+    calibrations. In practice, it is limited to 3, because it is currently
+    using the 3-region Vertical ROI fields included in the original (Rev 1)
+    EEPROM format. 
+
+    It is also practically limited to 2 calibrations because currently it's
+    using one EEPROM page per "extra" calibration, and the "standard 8" pages
+    only has one extra: page 7. This isn't a limitation on XS, which has a much
+    larger EEPROM than X series, so we could easily add more pages to subformat
+    5 if desired.
+
+    Calibration 0 is the "original calibration," and is stored in the "standard"
+    EEPROM pages where such things (wavecal, Raman Intensity, etc) have always
+    been stored. When loaded to memory, they are initially read into the EEPROM 
+    instance properties (.wavecal_coeffs, .excitation_float_nm etc) where they 
+    have always been stored. HOWEVER, this is not where "modern" code should
+    attempt to read or write them, as described below.
+
+    Additional calibrations (1+) are persisted on a single EEPROM page each (p7 
+    for calibration 1). When loaded from EEPROM, they are NOT stored in object
+    properties like Calibration 0, but are stored in a dict by calibration index
+    and their field name. For instance, the laser excitation wavelength of the
+    second calibration (calibration 1) is in values["excitation_nm_float"][1].
+
+    For consistency, working copies of calibration 0 fields are populated to
+    values[name][0]. New code is recommended to access even the old "calibration 
+    0" fields through the provided MultiWavelengthCalibration accessors (get()
+    and set()), as this will make the new code "future-proof" and multi-
+    calibration ready. All known Wasatch.PY and ENLIGHTEN references to 0-
+    calibration properties have been updated to use the new accessors as 
+    reference examples.
     """
 
     def __init__(self, eeprom):

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -399,7 +399,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
             if roi is not None:
                 self.set_vertical_binning(roi)
 
-        self.settings.init_regions()        
+        # self.settings.init_regions()        
 
         # ######################################################################
         # post-connection defaults

--- a/wasatch/ProcessedReading.py
+++ b/wasatch/ProcessedReading.py
@@ -238,6 +238,8 @@ class ProcessedReading:
         if self.settings and self.wavenumbers is None:
             self.wavenumbers = copy(self.settings.wavenumbers)
 
+        log.debug(f"PR.post_laod_cleanup: waveelngths {self.wavelengths[:10]}")
+
         for field in [ "processed", "raw", "dark", "reference", "recordable_dark", "recordable_reference", "wavelengths", "wavenumbers" ]:
             if hasattr(self, field):
                 array = getattr(self, field)

--- a/wasatch/ProcessedReading.py
+++ b/wasatch/ProcessedReading.py
@@ -238,8 +238,6 @@ class ProcessedReading:
         if self.settings and self.wavenumbers is None:
             self.wavenumbers = copy(self.settings.wavenumbers)
 
-        log.debug(f"PR.post_laod_cleanup: waveelngths {self.wavelengths[:10]}")
-
         for field in [ "processed", "raw", "dark", "reference", "recordable_dark", "recordable_reference", "wavelengths", "wavenumbers" ]:
             if hasattr(self, field):
                 array = getattr(self, field)

--- a/wasatch/SPIDevice.py
+++ b/wasatch/SPIDevice.py
@@ -254,8 +254,8 @@ class SPIDevice(InterfaceDevice):
         self.cmds["Gain dB"         ].value = self.gain_to_ff(eeprom.detector_gain)
         self.cmds["Start Line 0"    ].value = eeprom.roi_vertical_region_1_start
         self.cmds["Stop Line 0"     ].value = eeprom.roi_vertical_region_1_end
-        self.cmds["Start Column 0"  ].value = eeprom.roi_horizontal_start
-        self.cmds["Stop Column 0"   ].value = eeprom.roi_horizontal_end
+        self.cmds["Start Column 0"  ].value = eeprom.multi_wavelength_calibration.get("roi_horizontal_start")
+        self.cmds["Stop Column 0"   ].value = eeprom.multi_wavelength_calibration.get("roi_horizontal_end")
 
         return True
 

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -210,6 +210,11 @@ class SpectrometerSettings:
     # methods
     # ##########################################################################
 
+    def calibrations(self):
+        if self.eeprom.subformat != 5:
+            return 1
+        return self.eeprom.multi_wavelength_calibration.calibrations
+
     def select_calibration(self, calibration):
         log.debug("changing Multi-Wavelength Calibration to {calibration}")
         self.eeprom.multi_wavelength_calibration.selected_calibration = calibration
@@ -343,13 +348,13 @@ class SpectrometerSettings:
 
         if coeffs is None:
             coeffs = self.get_wavecal_coeffs()
-            log.debug(f"SS.update_wavecal: coeffs {coeffs}")
+            log.debug(f"update_wavecal: coeffs {coeffs}")
         else:
             log.debug("update_wavecal: passed coeffs, so storing to region {self.state.region}")
             self.set_wavecal_coeffs(coeffs)
 
         self.wavelengths = utils.generate_wavelengths(self.pixels(), coeffs)
-        log.debug(f"SS.update_wavecal: wavelengths {self.wavelengths[:10]}")
+        log.debug(f"update_wavecal: wavelengths {self.wavelengths[:10]}")
 
         if self.wavelengths is None:
             # this can happen on Stroker Protocol before/without .ini file,

--- a/wasatch/SpectrometerState.py
+++ b/wasatch/SpectrometerState.py
@@ -102,6 +102,7 @@ class SpectrometerState:
 
         # scan averaging
         self.scans_to_average = 1
+        self.onboard_averaging = False # whether averaging occurs in HW or SW
 
         # boxcar 
         self.boxcar_half_width = 0

--- a/wasatch/WasatchBus.py
+++ b/wasatch/WasatchBus.py
@@ -47,7 +47,7 @@ class USBBus:
     def update(self, poll = False):
         device_ids = []
         try:
-            log.debug("USBBus.update: instantiating DeviceFinderUSB")
+            # log.debug("USBBus.update: instantiating DeviceFinderUSB")
             device_ids = self.finder.find_usb_devices(poll=True)
         except USBError:
             # MZ: this seems to happen when I run from Git Bash shell
@@ -58,5 +58,5 @@ class USBBus:
         except Exception:
             log.critical("LIBUSB error", exc_info=1)
 
-        log.debug(f"USBBus.update: found {len(device_ids)}")
+        # log.debug(f"USBBus.update: found {len(device_ids)}")
         return device_ids

--- a/wasatch/__init__.py
+++ b/wasatch/__init__.py
@@ -1,4 +1,4 @@
 """This package is a driver for Wasatch Photonics spectrometers"""
 
-__version__ = "2.2.13"  # This is used by flit and other pypi things
+__version__ = "2.2.14"  # This is used by flit and other pypi things
 version = __version__   # This is to avoid breaking other files that originally used .version instead of __version__


### PR DESCRIPTION
This will resolve #126.

Changes:
- EEPROM
    - bumped revision to 17
    - added MultiWavelengthCalibration class to encapsulate new subformat 5 functionality
    - deprecated subformat 4 (old multi-ROI format, never used/released)
- SpectrometerSettings
    - deprecated old 'integer' wavelength_nm (from format <4)
    - moved vertical ROI from tuple(int, int) to wasatch.ROI
    - added calibrations(), select_calibration(n)
    - deprecated subformat 4 (regions)

Unintended changes (should have been on different branch):
- FeatureIdentificationDevice
    - added get/set_scans_to_average
- SpectrometerState
    - added onboard_averaging