### PR TITLE
ENLIGHTEN fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- 2025-11-06 2.3.6
+    - resolve hotplug race condition when laser power set in percent
+    - cache certain device getters to avoid I2C overruns
+    - stop trying to read laser temperature on FX2, it's never worked right
 - 2025-10-22 2.3.5
     - don't loop on spectral read errors on XS
 - 2025-10-22 2.3.4

--- a/wasatch/SpectrometerState.py
+++ b/wasatch/SpectrometerState.py
@@ -29,12 +29,15 @@ class SpectrometerState:
         # TEC       @todo rename detector_tec...
         self.tec_setpoint_degC = 15 # that's a very strange default...
         self.tec_enabled = False
+        self.detector_temperature_raw = None
+        self.detector_temperature_raw_last_refreshed = None
 
         # high gain mode (InGaAs only)
         self.high_gain_mode_enabled = False
 
         # laser
         self.laser_enabled = False
+        self.laser_enabled_last_refreshed = None
         self.laser_power_mW = None  # if last set in mW, will contain setpoint in mW; else will be None
         self.laser_power_perc = 0   # should always contain a number [0, 100]
         self.use_mW = False         # bool

--- a/wasatch/__init__.py
+++ b/wasatch/__init__.py
@@ -1,4 +1,4 @@
 """This package provides control of Wasatch Photonics spectrometers"""
 
-__version__ = "2.3.5"   # used by flit and other pypi things
+__version__ = "2.3.6"   # used by flit and other pypi things
 version = __version__   # legacy alias


### PR DESCRIPTION
- 2025-11-06 2.3.6
    - resolve hotplug race condition when laser power set in percent
    - cache certain device getters to avoid I2C overruns
    - stop trying to read laser temperature on FX2, it's never worked right