### PR TITLE
STARVIS testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
-- 2025-??-?? 2.3.8
+- 2026-01-12 2.3.8
     - added settings.has_detector
+    - improved support for Andor .json "virtual EEPROMs"
+    - bump internal WrapperWorker poll rate from 20Hz to 200Hz
+    - retain debug logging for 20sec after connection (vs previous 10sec)
+    - only update Andor detector temperature at 1Hz
+    - improved support for using 220250 boards as standalone laser drivers w/o 
+      detectors (added Reading.keep_alive to indicate metadata but no spectra)
 - 2025-12-10 2.3.7
     - added EEPROM.is_oem
     - fixed TCPDevice.set_detector_gain and set_vertical_roi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2025-??-?? 2.3.8
+    - added settings.has_detector
 - 2025-12-10 2.3.7
     - added EEPROM.is_oem
     - fixed TCPDevice.set_detector_gain and set_vertical_roi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- 2025-12-10 2.3.7
+    - added EEPROM.is_oem
+    - fixed TCPDevice.set_detector_gain and set_vertical_roi
+    - disable use of eeprom.actual_pixels_horizontal during acquisition
 - 2025-11-06 2.3.6
     - resolve hotplug race condition when laser power set in percent
     - cache certain device getters to avoid I2C overruns

--- a/demo-ids-raman.py
+++ b/demo-ids-raman.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+################################################################################
+#                              demo-ids-raman.py                               #
+################################################################################
+#                                                                              #
+#  DESCRIPTION:  Simple cmd-line demo to control an XS spectrometer using IDS  #
+#                detector and 220250 Rev4 laser driver.                        #
+#                                                                              #
+#  NOTES: This is for the fairly unusual case of having an XS bench built with #
+#         an IDS camera (providing its own USB3 port for comms and control),   #
+#         plus a 220250 Rev4 PCB for use as a standalone laser driver (but w/o #
+#         an IMX385 detector connected).                                       #
+#                                                                              #
+################################################################################
+
+# DEPENDENCIES: pywin32, psutil, seabreeze, pyftdi, crcmod, bleak
+
+import os
+import re
+import sys
+import time
+import numpy
+import signal
+import logging
+import datetime
+import argparse
+
+import wasatch
+from wasatch                      import applog
+from wasatch.DeviceID             import DeviceID
+from wasatch.IDSDevice            import IDSDevice
+from wasatch.WasatchBus           import WasatchBus
+from wasatch.WasatchDevice        import WasatchDevice
+
+log = logging.getLogger(__name__)
+
+class WasatchDemo:
+
+    ############################################################################
+    #                                                                          #
+    #                               Lifecycle                                  #
+    #                                                                          #
+    ############################################################################
+
+    def __init__(self):
+        self.bus     = None
+        self.camera_device = None
+        self.laser_device = None
+        self.logger  = None
+        self.outfile = None
+        self.exiting = False
+        self.reading_count = 0
+
+        self.args = self.parse_args()
+
+        if self.args.log_level != "NEVER":
+            self.logger = applog.MainLogger(self.args.log_level)
+        log.info("Wasatch.PY version %s", wasatch.__version__)
+
+    ############################################################################
+    #                                                                          #
+    #                             Command-Line Args                            #
+    #                                                                          #
+    ############################################################################
+
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description="Simple demo to acquire spectra from command-line interface")
+        parser.add_argument("--log-level",           type=str, default="INFO", help="logging level", choices=["DEBUG","INFO","WARNING","ERROR","CRITICAL","NEVER"])
+        parser.add_argument("--integration-time-ms", type=int, default=1000,   help="integration time (ms, default 10)")
+        parser.add_argument("--delay-ms",            type=int, default=1000,   help="delay between integrations (ms, default 1000)")
+        parser.add_argument("--outfile",             type=str, default=None,   help="output filename (e.g. path/to/spectra.csv)")
+        parser.add_argument("--max",                 type=int, default=0,      help="max spectra to acquire (default 0, unlimited)")
+
+        args = parser.parse_args()
+        args.log_level = args.log_level.upper()
+
+        return args
+        
+    ############################################################################
+    #                                                                          #
+    #                              USB Devices                                 #
+    #                                                                          #
+    ############################################################################
+
+    def connect(self):
+        """ Connect to all discoverable Wasatch spectrometers.  """
+
+        ########################################################################
+        # Look for laser driver board
+        ########################################################################
+
+        if self.bus is None:
+            self.bus = WasatchBus()
+        if not self.bus.device_ids:
+            print("No Wasatch USB spectrometers found.")
+            return 
+
+        # look for laser driver on WasatchBus -- we won't see the camera here,
+        # because IDSPeak devices are not automatically considered for inclusion
+        # by WasatchBus (although they could be)
+        for device_id in self.bus.device_ids:
+            log.debug("connect: trying to connect to %s", device_id)
+            device = WasatchDevice(device_id)
+            ok = device.connect()
+            if not ok:
+                log.critical("connect: can't connect to %s", device_id)
+                continue
+
+            log.debug(f"connect: connected to {device_id} ({device})")
+            if device.settings is None:
+                log.error("can't have device without SpectrometerSettings")
+                continue
+
+            print(f"connected to {device.settings.full_model()} {device.settings.eeprom.serial_number} with {device.settings.pixels()} pixels " +
+                  f"from ({device.settings.wavelengths[0]:.2f}, {device.settings.wavelengths[-1]:.2f}nm)" +
+                  (   f" ({device.settings.wavenumbers[0]:.2f}, {device.settings.wavenumbers[-1]:.2f}cm⁻¹)" if device.settings.has_excitation() else "") +
+                  f" (Microcontroller {device.settings.microcontroller_firmware_version}," +
+                  f" FPGA {device.settings.fpga_firmware_version})")
+
+            self.laser_device = device
+            break
+        if self.laser_device is None:
+            log.critical("Could not find laser driver, exitting")
+            return False
+
+        ########################################################################
+        # now look for an IDS camera
+        ########################################################################
+
+        try:
+            device_id = DeviceID(label="IDSPeak")
+            device = IDSDevice(device_id=device_id)
+            if device.connect():
+                log.info("Successfully connected to IDSPeak camera")
+                self.camera_device = device
+            else:
+                log.error("Failed to connecting to IDSCamera")
+        except:
+            log.critical("Exception connecting to IDS camera", exc_info=1)
+
+        if self.camera_device is None:
+            log.critical("Could not find IDS camera, exitting")
+            return False
+
+        return True
+
+    ############################################################################
+    #                                                                          #
+    #                               Run-Time Loop                              #
+    #                                                                          #
+    ############################################################################
+
+    def run(self):
+        log.info("Wasatch.PY %s IDS Raman Demo", wasatch.__version__)
+
+        # apply initial settings
+        self.camera_device.set_integration_time_ms(self.args.integration_time_ms)
+
+        # initialize outfile if one was specified
+        if self.args.outfile:
+            try:
+                self.outfile = open(self.args.outfile, "w")
+                self.outfile.write("time,temp,serial,spectrum\n")
+            except:
+                log.error("Error initializing %s", self.args.outfile)
+                self.outfile = None
+
+        # read spectra until user presses Control-Break
+        while not self.exiting:
+            start_time = datetime.datetime.now()
+
+            # take a spectrum 
+            log.debug(f"calling attempt_reading")
+            self.attempt_reading(self.camera_device)
+
+            end_time = datetime.datetime.now()
+
+            if self.args.max > 0 and self.reading_count >= self.args.max:
+                log.debug("max spectra reached, exiting")
+                self.exiting = True
+            else:
+                # compute how much longer we should wait before the next "tick"
+                reading_time_ms = int((end_time - start_time).microseconds / 1000)
+                sleep_ms = self.args.delay_ms - reading_time_ms
+                if sleep_ms > 0:
+                    log.debug("sleeping %d ms (%d ms already passed)", sleep_ms, reading_time_ms)
+                    try:
+                        time.sleep(float(sleep_ms) / 1000)
+                    except:
+                        self.exiting = True
+
+        log.debug("WasatchDemo.run exiting")
+
+    def attempt_reading(self, device):
+        try:
+            reading_response = device.acquire_data()
+        except:
+            log.critical("attempt_reading caught exception", exc_info=1)
+            self.exiting = True
+            return
+
+        if reading_response.keep_alive:
+            log.debug(f"ignoring keepalive from {device}")
+            return
+
+        if isinstance(reading_response.data, bool):
+            if reading_response.data:
+                log.debug("received poison-pill, exiting")
+                self.exiting = True
+                return
+            else:
+                log.debug("no reading available")
+                return
+
+        if reading_response.data.failure:
+            self.exiting = True
+            return
+
+        self.process_reading(reading_response.data)
+
+    def process_reading(self, reading):
+        if (self.exiting or 
+            (self.args.max > 0 and self.reading_count >= self.args.max)):
+            return
+
+        settings = self.camera_device.settings
+
+        self.reading_count += 1
+        spectrum = reading.spectrum
+
+        spectrum_min = numpy.amin(spectrum)
+        spectrum_max = numpy.amax(spectrum)
+        spectrum_avg = numpy.mean(spectrum)
+        spectrum_std = numpy.std (spectrum)
+
+        print("%s: %s %4d  Detector: %5.2f degC  Min: %8.2f  Max: %8.2f  Avg: %8.2f  StdDev: %8.2f" % (
+            reading.timestamp,
+            settings.eeprom.serial_number,
+            self.reading_count,
+            reading.detector_temperature_degC,
+            spectrum_min,
+            spectrum_max,
+            spectrum_avg,
+            spectrum_std))
+        log.debug("%s", str(reading))
+
+        if self.outfile:
+            self.outfile.write("%s,%.2f,%s,%s\n" % (datetime.datetime.now(),
+                                                 reading.detector_temperature_degC,
+                                                 settings.eeprom.serial_number,
+                                                 ",".join(format(x, ".2f") for x in spectrum)))
+
+################################################################################
+# main()
+################################################################################
+
+def signal_handler(signal, frame):
+    print('\rInterrupted by Ctrl-C...shutting down', end=' ')
+    clean_shutdown()
+
+def clean_shutdown():
+    log.debug("Exiting")
+    if demo:
+        if demo.laser_device is not None:
+            demo.laser_device.disconnect()
+            time.sleep(1)
+        if demo.camera_device is not None:
+            demo.camera_device.disconnect()
+            time.sleep(1)
+        if demo.logger:
+            log.debug("closing logger")
+            log.debug(None)
+            demo.logger.close()
+            time.sleep(1)
+            applog.explicit_log_close()
+    sys.exit()
+
+demo = None
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, signal_handler)
+
+    demo = WasatchDemo()
+    if demo.connect():
+        # Note that on Windows, Control-Break (SIGBREAK) differs from 
+        # Control-C (SIGINT); see https://stackoverflow.com/a/1364199
+        log.debug("Press Control-Break to interrupt...")
+        demo.run()
+
+    clean_shutdown()

--- a/demo-ids-raman.py
+++ b/demo-ids-raman.py
@@ -63,7 +63,6 @@ class WasatchDemo:
         parser.add_argument("--prefix",              type=str, default="ids-raman", help="filename prefix")
 
         args = parser.parse_args()
-        # logging.getLogger().setLevel(args.log_level)
         applog.MainLogger(args.log_level)
 
         return args

--- a/wasatch/AreaScanImage.py
+++ b/wasatch/AreaScanImage.py
@@ -16,4 +16,4 @@ class AreaScanImage:
         AreaScanImage.FRAME_COUNT += 1
 
     def __repr__(self):
-        return f"AreaScanImage<frame {self.frame_count}, line_index {line_index}, width {self.width} (orig {self.width_orig}), height {self.height} (orig {self.height_orig}), format_name {self.format_name}, pathname_png {self.pathname_png}>"
+        return f"AreaScanImage<frame {self.frame_count}, line_index {self.line_index}, width {self.width} (orig {self.width_orig}), height {self.height} (orig {self.height_orig}), format_name {self.format_name}, pathname_png {self.pathname_png}>"

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -123,6 +123,8 @@ class EEPROM:
         self.sig_laser_tec               = False # better: sig_sml_laser_tec
         self.has_interlock_feedback      = False
         self.laser_interlock_excluded    = False # True if the unit has a laser, but the normal safety interlock has been removed or otherwise disabled (OEM-only)
+        self.laser_timeout_after_count   = False
+        self.is_oem                      = False
         self.has_shutter                 = False
         self.disable_ble_power           = False
         self.disable_laser_armed_indicator = False
@@ -506,6 +508,8 @@ class EEPROM:
             self.disable_ble_power             = 0 != self.feature_mask & 0x0100
             self.disable_laser_armed_indicator = 0 != self.feature_mask & 0x0200
             self.laser_interlock_excluded      = 0 != self.feature_mask & 0x0400
+            self.laser_timeout_after_count     = 0 != self.feature_mask & 0x0800
+            self.is_oem                        = 0 != self.feature_mask & 0x1000
         else:
             self.invert_x_axis                 = False 
             self.horiz_binning_enabled         = False
@@ -517,6 +521,9 @@ class EEPROM:
             self.has_shutter                   = False
             self.disable_ble_power             = False 
             self.disable_laser_armed_indicator = False
+            self.laser_interlock_excluded      = False
+            self.laser_timeout_after_count     = False
+            self.is_oem                        = False
 
         # ######################################################################
         # sanity checks
@@ -562,6 +569,8 @@ class EEPROM:
         mask |= 0x0100 if self.disable_ble_power             else 0
         mask |= 0x0200 if self.disable_laser_armed_indicator else 0
         mask |= 0x0400 if self.laser_interlock_excluded      else 0
+        mask |= 0x0800 if self.laser_timeout_after_count     else 0
+        mask |= 0x1000 if self.is_oem                        else 0
         return mask
 
     ##

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -869,6 +869,8 @@ class EEPROM:
                 else:
                     buf[start_byte + i] = 0
         else:
+            if data_type == "f":
+                value = float(value)
             struct.pack_into(data_type, buf, start_byte, value)
 
         if False:

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -66,11 +66,11 @@ class FeatureIdentificationDevice(InterfaceDevice):
                                        |
                                 handle_requests
                                        |
-                                 ------------
-                                /   /  |  \  \ 
+                                  -----------
+                                 |  |  |  |  | 
              { get_laser status, acquire, set_laser_watchdog, etc....}
-                                \   \  |  /  /
-                                 ------------
+                                 |  |  |  |  | 
+                                  -----------
                                        |
                                    _send_code
     @endverbatim

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -185,14 +185,14 @@ class FeatureIdentificationDevice(InterfaceDevice):
         # it doesn't know what PIDs it might be looking for.  We know, so just
         # narrow down the search to those devices.
 
-        log.info(f"FID.connect: asked to connect to device_type {self.device_type}")
-        log.info(f"FID.connect: calling device_type.find, looking for VID 0x{self.device_id.vid:04x} and PID 0x{self.device_id.pid:04x}")
+        log.debug(f"FID.connect: asked to connect to device_type {self.device_type}")
+        log.debug(f"FID.connect: calling device_type.find, looking for VID 0x{self.device_id.vid:04x} and PID 0x{self.device_id.pid:04x}")
         devices = self.device_type.find(find_all=True, idVendor=self.device_id.vid, idProduct=self.device_id.pid)
-        log.info(f"FID.connect: found devices {devices}")
+        log.debug(f"FID.connect: found devices {devices}")
         dev_list = list(devices) # convert from array
 
         device = None
-        log.info(f"searching for specified device in dev_list {dev_list}")
+        log.debug(f"searching for specified device in dev_list {dev_list}")
         for dev in dev_list:
             if dev.bus != self.device_id.bus:
                 log.debug("FID.connect: rejecting device (bus %d != requested %d)", dev.bus, self.device_id.bus)
@@ -475,7 +475,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
         self.connected = False
 
-        log.critical("fid.disconnect: releasing interface")
+        log.debug("fid.disconnect: releasing interface")
         try:
             #result = self.device_type.release_interface(self.device, 0)
             try:
@@ -520,7 +520,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         # I had to look at the full configuration string and saw that the way to get the instance id was the following
         # using _try_get_string https://github.com/pyusb/pyusb/blob/master/usb/core.py#L1221
         # so techincally we shouldn't do this by the _ meaning it should be private, but it's the only way I see
-        device_instance_id = f'USB\VID_{self.device_id.vid:04X}&PID_{self.device_id.pid:04X}\{usb.core._try_get_string(pyusb_devices[0], pyusb_devices[0].iSerialNumber)}'
+        device_instance_id = f'USB/VID_{self.device_id.vid:04X}&PID_{self.device_id.pid:04X}/{usb.core._try_get_string(pyusb_devices[0], pyusb_devices[0].iSerialNumber)}'
         log.debug(f"In reset and restart trying to reset instance id {device_instance_id}")
         subprocess.run(["pnputil", r"/reboot", r"/disable-device", device_instance_id])
         subprocess.run(["pnputil", r"/reboot", r"/enable-device", device_instance_id])
@@ -3008,13 +3008,13 @@ class FeatureIdentificationDevice(InterfaceDevice):
         log.debug(f"set_vertical_roi: start {start}, end {end}")
 
         if start < 0 or end < 0:
-            log.error("set_vertical_roi: requires POSITIVE (start, stop) lines")
+            log.debug("set_vertical_roi: requires POSITIVE (start, stop) lines")
             return SpectrometerResponse(data=False, error_msg="invalid start and stop lines")
 
         # enforce ascending order (also, note that stop line is "last line binned + 1", so stop must be > start)
         if start >= end:
             # (start, end) = (end, start)
-            log.error("set_vertical_roi: requires ascending order (ignoring %d, %d)", start, end)
+            log.debug("set_vertical_roi: requires ascending order (ignoring %d, %d)", start, end)
             return SpectrometerResponse(data=False, error_msg="invalid start and stop lines")
 
         if self.settings.is_xs():

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -1361,7 +1361,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         ########################################################################
 
         # this is the number of pixels we expect to read-out over USB
-        if self.settings.is_imx385():
+        if False and self.settings.is_imx385():
             # Currently, only the IMX385 uses horizontal binning, so for now 
             # limit code changes to that detector (even though they haven't been
             # shown to break other hardware)
@@ -1633,6 +1633,10 @@ class FeatureIdentificationDevice(InterfaceDevice):
         """
         if not self.settings.is_xs():
             return SpectrometerResponse(False)
+
+        # MZ: Kludge, disabling while testing
+        log.debug("disabling internal averaging")
+        return SpectrometerResponse(False)
 
         retval = self._send_code(0xff, 0x62, n, label="SET_ONBOARD_SCANS_TO_AVERAGE")
         self.settings.state.scans_to_average = n

--- a/wasatch/Reading.py
+++ b/wasatch/Reading.py
@@ -40,6 +40,7 @@ class Reading:
         self.take_one_request          = None
         self.elapsed_from_request      = None
         self.elapsed_since_last        = None
+        self.keep_alive                = False
 
         # currently only populated by AutoRaman
         self.new_integration_time_ms   = None

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -155,6 +155,10 @@ class SpectrometerSettings:
         else:
             return False
 
+    def has_detector(self):
+        det = self.eeprom.detector
+        return det is not None and len(det) > 0 and det.lower() != "none"
+
     def has_excitation(self):
         return self.excitation() > 0
 

--- a/wasatch/WasatchDevice.py
+++ b/wasatch/WasatchDevice.py
@@ -173,14 +173,8 @@ class WasatchDevice(InterfaceDevice):
 
         dev = None
         try:
-            log.debug(f"connect_fid: instantiating FID with device_id {self.device_id}, pid {pid_hex}")
             dev = FeatureIdentificationDevice(device_id=self.device_id, message_queue=self.message_queue, alert_queue=self.alert_queue)
-            log.debug("connect_fid: instantiated")
-
-            log.debug("connect_fid: calling dev.connect")
             response = dev.connect()
-            log.debug("connect_fid: back from dev.connect")
-
             if not response.data:
                 log.critical("Low level failure in device connect")
                 return response
@@ -414,15 +408,15 @@ class WasatchDevice(InterfaceDevice):
             log.debug(f"floating up take_one_averaged_reading poison pill {take_one_response}")
             return take_one_response
         elif take_one_response.keep_alive:
-            log.debug(f"floating up keep alive")
-            return take_one_response
+            # log.debug(f"acquire_spectrum_standard: declining to float up keep alive")
+            pass
         elif take_one_response.data is None:
             log.debug(f"Received a none reading, floating it up {take_one_response}")
             return take_one_response
 
         # don't perform dark subtraction, but pass the dark measurement along
         # with the averaged reading
-        if dark_reading.data is not None:
+        if dark_reading.data is not None and not reading.keep_alive:
             reading.dark = dark_reading.data.spectrum
             log.debug(f"attaching dark to reading (mean {np.mean(reading.dark)}, min {min(reading.dark)}, max {max(reading.dark)})")
             log.debug(f"reading spectrum          (mean {np.mean(reading.spectrum)}, min {min(reading.spectrum)}, max {max(reading.spectrum)})")
@@ -620,7 +614,7 @@ class WasatchDevice(InterfaceDevice):
         if auto_enable_laser:
             log.debug(f"AUTO-RAMAN ==> done")
 
-        if tor:
+        if tor and not reading.keep_alive:
             reading.take_one_request = tor
 
             # this was for a "fast BatchCollection" with a streaming multi-reading TakeOneRequest
@@ -698,9 +692,6 @@ class WasatchDevice(InterfaceDevice):
         @returns Reading on success, true or false on "stop processing" conditions
         """
 
-        if not self.settings.has_detector():
-            return SpectrometerResponse(keep_alive=True)
-            
         take_one_response = SpectrometerResponse()
 
         if self.take_one_request:
@@ -727,6 +718,7 @@ class WasatchDevice(InterfaceDevice):
             req = SpectrometerRequest("get_spectrum")
             res = self.hardware.handle_requests([req])[0]
             if res.error_msg != '':
+                log.debug(f"take_one_averaged_reading: returning while handling pending throwaways because error_msg {res.error_msg}")
                 return res
 
         # either take one measurement (normal), or a bunch (sum_locally)
@@ -752,10 +744,12 @@ class WasatchDevice(InterfaceDevice):
             # of timeouts)
             externally_triggered = self.settings.state.trigger_source == SpectrometerState.TRIGGER_SOURCE_EXTERNAL
             try:
+                keep_alive = False
                 while True:
                     req = SpectrometerRequest("get_spectrum")
                     res = self.hardware.handle_requests([req])[0]
                     if res.error_msg != '':
+                        log.debug(f"take_one_averaged_reading: returning due to error_msg {res.error_msg}")
                         return res
 
                     # @todo get rid of spectrum_and_row...get_spectrum() can go back to only returning spectrum
@@ -764,10 +758,12 @@ class WasatchDevice(InterfaceDevice):
                         # float up poison
                         take_one_response.transfer_response(res)
                         return take_one_response
+
                     if res.keep_alive:
-                        # float up keep alive
-                        take_one_response.transfer_response(res)
-                        return take_one_response
+                        log.debug(f"take_one_averaged_reading: flagging reading as keep_alive (no spectra)")
+                        keep_alive = True
+                        break
+
                     if isinstance(spectrum_and_row, bool):
                         # get_spectrum returned a poison-pill, so flow it upstream
                         take_one_response.poison_pill = True
@@ -786,10 +782,16 @@ class WasatchDevice(InterfaceDevice):
                     else:
                         break
 
-                reading.spectrum            = spectrum_and_row.spectrum
+                reading.keep_alive = keep_alive
+                if reading.keep_alive:
+                    log.debug(f"take_one_averaged_reading: trying to populate keep_alive")
+                    reading.spectrum = None
+                else:
+                    reading.spectrum = spectrum_and_row.spectrum
+                    log.debug(f"take_one_averaged_reading: got {reading.spectrum[0:9]}")
+
                 reading.timestamp_complete  = datetime.datetime.now()
 
-                log.debug(f"take_one_averaged_reading: got {reading.spectrum[0:9]}")
             except Exception as exc:
                 # if we got the timeout after switching from externally triggered back to internal, let it ride
                 take_one_response.error_msg = exc
@@ -841,7 +843,7 @@ class WasatchDevice(InterfaceDevice):
             # we should probably perform the summation in ENLIGHTEN too (for
             # non-TakeOneRequest averages).
 
-            if not reading.failure:
+            if not reading.failure and not reading.keep_alive:
                 # log.debug("take_one_averaged_reading: not failure")
                 if sum_locally:
                     log.debug("take_one_averaged_reading: summing locally")
@@ -856,26 +858,28 @@ class WasatchDevice(InterfaceDevice):
                     log.debug("take_one_averaged_reading: summed_spectra : %s ...", self.summed_spectra[0:9])
 
             # count spectra
-            self.session_reading_count += 1
+            if not reading.keep_alive:
+                self.session_reading_count += 1
             reading.session_count = self.session_reading_count
             reading.sum_count = self.sum_count
             log.debug(f"take_one_averaged_reading: reading.sum_count now {reading.sum_count}, session_count {reading.session_count}")
 
             # have we completed the averaged reading?
-            if sum_locally: 
-                log.debug(f"take_one_averaged_reading: checking for completion self.sum_count {self.sum_count} >?= scans_to_average {scans_to_average}")
-                if self.sum_count >= scans_to_average:
-                    reading.spectrum = [ x / self.sum_count for x in self.summed_spectra ]
-                    log.debug("take_one_averaged_reading: averaged_spectrum : %s ...", reading.spectrum[0:9])
-                    reading.averaged = True
+            if not reading.keep_alive:
+                if sum_locally: 
+                    log.debug(f"take_one_averaged_reading: checking for completion self.sum_count {self.sum_count} >?= scans_to_average {scans_to_average}")
+                    if self.sum_count >= scans_to_average:
+                        reading.spectrum = [ x / self.sum_count for x in self.summed_spectra ]
+                        log.debug("take_one_averaged_reading: averaged_spectrum : %s ...", reading.spectrum[0:9])
+                        reading.averaged = True
 
-                    # reset for next average
-                    self.summed_spectra = None
-                    self.sum_count = 0
-            else:
-                # if averaging isn't enabled...then a single reading is the
-                # "averaged" final measurement (check reading.sum_count to confirm)
-                reading.averaged = True
+                        # reset for next average
+                        self.summed_spectra = None
+                        self.sum_count = 0
+                else:
+                    # if averaging isn't enabled...then a single reading is the
+                    # "averaged" final measurement (check reading.sum_count to confirm)
+                    reading.averaged = True
 
         log.debug("device.take_one_averaged_reading: returning %s", reading)
         take_one_response.data = reading

--- a/wasatch/WasatchDeviceWrapper.py
+++ b/wasatch/WasatchDeviceWrapper.py
@@ -371,6 +371,7 @@ class WasatchDeviceWrapper:
             if wrapper_response.keep_alive or wrapper_response.data is None:
                 # If that keep alive is associated with an error though float it up
                 if wrapper_response.keep_alive and wrapper_response.error_msg:
+                    log.debug(f"get_final_item: ignoring keepalive WITH error_msg {wrapper_response.error_msg}")
                     last_response = wrapper_response
                     break
                 log.debug("get_final_item: ignoring keepalive")

--- a/wasatch/__init__.py
+++ b/wasatch/__init__.py
@@ -1,4 +1,4 @@
 """This package provides control of Wasatch Photonics spectrometers"""
 
-__version__ = "2.3.7"   # used by flit and other pypi things
+__version__ = "2.3.8"   # used by flit and other pypi things
 version = __version__   # legacy alias

--- a/wasatch/__init__.py
+++ b/wasatch/__init__.py
@@ -1,4 +1,4 @@
 """This package provides control of Wasatch Photonics spectrometers"""
 
-__version__ = "2.3.6"   # used by flit and other pypi things
+__version__ = "2.3.7"   # used by flit and other pypi things
 version = __version__   # legacy alias

--- a/wasatch/applog.py
+++ b/wasatch/applog.py
@@ -135,7 +135,7 @@ class MainLogger:
         root_log = logging.getLogger()
         self.log_configurer(self.logfile, append)
         root_log.setLevel(self.log_level)
-        root_log.warning("Top level log configuration (%d handlers, get_location %s)", len(root_log.handlers), get_location())
+        root_log.debug("Top level log configuration (%d handlers, get_location %s)", len(root_log.handlers), get_location())
 
     ## Setup file handler and command window stream handlers. Every log
     #  message received on the queue handler will use these log configurers. 

--- a/wasatch/utils.py
+++ b/wasatch/utils.py
@@ -54,7 +54,7 @@ def generate_wavelengths(pixels, coeffs):
     for x in range(pixels):
         wavelength = 0.0
         for i in range(len(coeffs)):
-            wavelength += coeffs[i] * pow(x, i)
+            wavelength += float(coeffs[i]) * pow(x, i)
         wavelengths.append(wavelength)
     return wavelengths            
 


### PR DESCRIPTION
- 2026-01-12 2.3.8
    - added settings.has_detector
    - improved support for Andor .json "virtual EEPROMs"
    - bump internal WrapperWorker poll rate from 20Hz to 200Hz
    - retain debug logging for 20sec after connection (vs previous 10sec)
    - only update Andor detector temperature at 1Hz 
    - improved support for using 220250 boards as standalone laser drivers w/o 
      detectors (added Reading.keep_alive to indicate metadata but no spectra)
