### PR TITLE
BLE PWM, Auto-Collection, new EEPROM fields, more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
     - tweak laser password validation logic
     - laser PWM works
     - starting to consider Safe Mode
-    - consolidating EEPROM backup location
+    - enabled get_microcontroller_serial_number
+    - testing get_power_connection_state
+    - added periodic check for late-arriving attributes like ble_firmware_version
+    - EEPROM updates
+        - bumped to version 19
+        - consolidating backup location
+        - deprecated baud_rate, linearity_coeffs
+        - added max_laser_temp_deg_c
+        - added assembly_revision (and AssemblyRevision)
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - 2026-??-?? 2.3.25
     - tweak laser password validation logic
     - laser PWM works
+    - starting to consider Safe Mode
+    - consolidating EEPROM backup location
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 2026-??-?? 2.3.25
+    - tweak laser password validation logic
+    - testing laser PWM
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - enabled get_microcontroller_serial_number
     - testing get_power_connection_state
     - added periodic check for late-arriving attributes like ble_firmware_version
+    - add default laser warning delay sec for old FW
     - EEPROM updates
         - bumped to version 19
         - consolidating backup location
@@ -30,7 +31,12 @@
             - max_laser_temp_deg_c
             - pixel_calibration_type
             - startup_laser_tec_setpoint
-
+    - InterfaceDevice
+        - moved message_queue, alert_queue up from WasatchDevice/FID
+    - IDSDevice
+        - added laser_device (incl EEPROM)
+    - AutoRaman
+        - added auto_collection_mode for IDS
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,26 @@
         - bumped to version 19
         - consolidating backup location
         - deprecated baud_rate, linearity_coeffs
-        - added max_laser_temp_deg_c
-        - added assembly_revision (and AssemblyRevision)
         - made EEPROM subclasses JSON serializable (hopefully)
         - fixed EEPROM.pack for binary types ("*")
+        - moved further into (un)pack_field
+        - revisited user_text / user_data relationship
+        - added:
+            - acc_cont_strobe_count
+            - acc_cont_strobe_delay_us
+            - acc_cont_strobe_period_us
+            - acc_cont_strobe_width_us
+            - acc_state
+            - acc_state_gpio1
+            - acc_state_gpio2
+            - assembly_revision (and AssemblyRevision)
+            - feature_mask_xs
+            - light_source_type
+            - max_battery_temp_deg_c
+            - max_laser_temp_deg_c
+            - pixel_calibration_type
+            - startup_laser_tec_setpoint
+
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
         - deprecated baud_rate, linearity_coeffs
         - added max_laser_temp_deg_c
         - added assembly_revision (and AssemblyRevision)
+        - made EEPROM subclasses JSON serializable (hopefully)
+        - fixed EEPROM.pack for binary types ("*")
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Changelog
 
 - 2026-??-?? 2.3.25
-    - tweak laser password validation logic
-    - laser PWM works
-    - starting to consider Safe Mode
-    - enabled get_microcontroller_serial_number
-    - testing get_power_connection_state
-    - added periodic check for late-arriving attributes like ble_firmware_version
-    - add default laser warning delay sec for old FW
+    - USB
+        - enabled get_microcontroller_serial_number
+        - testing get_power_connection_state
+        - added periodic check for late-arriving attributes like ble_firmware_version
+    - BLE
+        - laser PWM works
+    - Laser control
+        - tweak laser password validation logic
+        - add default laser warning delay sec for old FW
+    - InterfaceDevice
+        - moved message_queue, alert_queue up from WasatchDevice/FID
+    - IDSDevice
+        - added laser_device (incl EEPROM)
+        - support Auto-Raman
     - EEPROM updates
         - bumped to version 19
         - consolidating backup location
@@ -31,12 +38,7 @@
             - max_laser_temp_deg_c
             - pixel_calibration_type
             - startup_laser_tec_setpoint
-    - InterfaceDevice
-        - moved message_queue, alert_queue up from WasatchDevice/FID
-    - IDSDevice
-        - added laser_device (incl EEPROM)
-    - AutoRaman
-        - added auto_collection_mode for IDS
+    - starting to consider Safe Mode
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - 2026-??-?? 2.3.25
     - tweak laser password validation logic
-    - testing laser PWM
+    - laser PWM works
 - 2026-04-18 2.3.24
     - add avg_resolution to IDSDevice EEPROM
     - change XS attenuator default from 127 to 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     - IDSDevice
         - added laser_device (incl EEPROM)
         - support Auto-Raman
+    - AndorDevice
+        - STARTED shutter fixes
     - EEPROM updates
         - bumped to version 19
         - consolidating backup location

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wasatch"
-version = "2.3.24"
+version = "2.3.25"
 description= "Application-level driver for Wasatch Photonics spectrometers"
 requires-python = ">=3.9"
 readme = "README.md"

--- a/wasatch/AbstractUSBDevice.py
+++ b/wasatch/AbstractUSBDevice.py
@@ -1,5 +1,7 @@
-
 class AbstractUSBDevice:
+    """
+    This is NOT an InterfaceDevice. This is used by MockUSBDevice and RealUSBDevice.
+    """
 
     def __init__(self):
         pass

--- a/wasatch/AndorDevice.py
+++ b/wasatch/AndorDevice.py
@@ -214,8 +214,11 @@ class AndorDevice(InterfaceDevice):
             return
 
     def set_fan_enable(self, x):
-        self.check_result(self.driver.SetFanMode(int(x)), f"Andor Fan On {x}")
-        return SpectrometerResponse()
+        try:
+            self.check_result(self.driver.SetFanMode(int(x)), f"Andor Fan On {x}")
+        except:
+            return SpectrometerResponse(False)
+        return SpectrometerResponse(True)
 
     def _get_default_data_dir(self):
         if os.name == "nt":

--- a/wasatch/AndorDevice.py
+++ b/wasatch/AndorDevice.py
@@ -55,28 +55,14 @@ class AndorDevice(InterfaceDevice):
     DRIVER_NOT_INSTALLED = False
 
     def __init__(self, device_id, message_queue=None, alert_queue=None):
-        # if passed a string representation of a DeviceID, deserialize it
-        super().__init__()
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
         if self.DRIVER_NOT_INSTALLED:
             raise InterfaceDeviceClassUnavailable("Andor driver not installed")
 
-        if type(device_id) is str:
-            device_id = DeviceID(label=device_id)
-
-        self.device_id      = device_id
-        self.message_queue  = message_queue
-        self.alert_queue    = alert_queue
-
         self.load_error_codes()
 
         self.connected = False
-
-        # Receives ENLIGHTEN's 'change settings' commands in the spectrometer
-        # process. 
-        self.command_queue = []
-
-        self.immediate_mode = False
 
         # An AndorDevice has-a SpectrometerSettings, which has-a EEPROM, which 
         # has-a MultiWavelengthCalibration
@@ -570,6 +556,7 @@ class AndorDevice(InterfaceDevice):
                 self.settings.eeprom.multi_wavelength_calibration.set(v, self.config_values[k])
 
         # same spelling
+        # consider just using self.settings.eeprom.fields.keys()
         for k in [ 'model', 
                    'stubbed', 
                    'detector', 

--- a/wasatch/AndorDevice.py
+++ b/wasatch/AndorDevice.py
@@ -378,11 +378,27 @@ class AndorDevice(InterfaceDevice):
             return self.temperature_cache_value
 
     def _close_ex_shutter(self):
+        # SetShutterEx(typ, internalMode, closingTimeMS, openingTimeMS, externalMode)
+        # where:
+        # - typ: 
+        #       0 = output TTL LOW to open shutter
+        #       1 = output TTL HIGH to open shutter
+        #
+        # - mode:
+        #       0 = Fully Auto
+        #       1 = Permanently Open
+        #       2 = Permanently Closed
+        #       3 = UNDEFINED
+        #       4 = Open for FVB series
+        #       5 = Open for any series
+
+        # set TTL HIGH="open", internalMode PermanentlyOpen, externalMode PermanentlyClosed
         self.check_result(self.driver.SetShutterEx(1, 1, self.SHUTTER_SPEED_MS, self.SHUTTER_SPEED_MS, 2), "SetShutterEx(2)")
         self.settings.state.shutter_enabled = False
         return SpectrometerResponse(True)
 
     def _open_ex_shutter(self):
+        # set TTL HIGH="open", internalMode PermanentlyOpen, externalMode PermanentlyOpen
         self.check_result(self.driver.SetShutterEx(1, 1, self.SHUTTER_SPEED_MS, self.SHUTTER_SPEED_MS, 1), "SetShutterEx(1)")
         self.settings.state.shutter_enabled = True
         return SpectrometerResponse(True)
@@ -450,6 +466,7 @@ class AndorDevice(InterfaceDevice):
         self.init_detector_speed() # step 12+13
 
         # step 14
+        # set internal shutter to PermanentlyOpen, external shutter to Automatic
         self.check_result(self.driver.SetShutterEx(1, 1, self.SHUTTER_SPEED_MS, self.SHUTTER_SPEED_MS, 0), "SetShutterEx(fully automatic external with internal always open)")
         self.settings.state.shutter_enabled = True
 

--- a/wasatch/AssemblyRevision.py
+++ b/wasatch/AssemblyRevision.py
@@ -1,9 +1,12 @@
-class AssemblyRevision:
+import json
+
+class AssemblyRevision(dict):
     """
     Making this a standalone class because might end up using from both FID (USB)
     and BLEDevice.
     """
     def __init__(self, data=None):
+        dict.__init__(self) # https://stackoverflow.com/a/31207881
         self.partnumber = None
         self.variant = None
         self.revision = None

--- a/wasatch/AssemblyRevision.py
+++ b/wasatch/AssemblyRevision.py
@@ -47,7 +47,7 @@ class AssemblyRevision(dict):
 
     def __repr__(self):
         s = ""
-        if self.partnumber:
+        if self.partnumber and self.partnumber != 140_000:
             s += f"{self.partnumber}"
             if self.variant:
                 s += f"-{self.variant}"

--- a/wasatch/AssemblyRevision.py
+++ b/wasatch/AssemblyRevision.py
@@ -1,0 +1,49 @@
+class AssemblyRevision:
+    """
+    Making this a standalone class because might end up using from both FID (USB)
+    and BLEDevice.
+    """
+    def __init__(self, data=None):
+        self.partnumber = None
+        self.variant = None
+        self.revision = None
+
+        self.parse_data(data)
+
+    def parse_data(self, data):
+        """
+        This is based on the data structure defined in ENG-0120 Rev 10.
+        """
+        if data is None or len(data) != 6:
+            log.error(f"parse_data: invalid length {data}")
+            return
+
+        self.partnumber = (data[0] << 8) + data[1] + 140_000
+        self.variant    = (data[2] << 8) + data[3]
+        self.revision   = (data[4] << 8) + data[5]
+
+    def serialize(self):
+        """ probably a simpler way to do this with struct """
+        buf = [ 0 ] * 6
+        if self.partnumber:
+            n = self.partnumber - 140_000
+            buf[0] = (n >> 8) & 0xff
+            buf[1] = n & 0xff
+        if self.variant:
+            n = self.variant
+            buf[2] = (n >> 8) & 0xff
+            buf[3] = n & 0xff
+        if self.revision:
+            n = self.revision
+            buf[4] = (n >> 8) & 0xff
+            buf[5] = n & 0xff
+
+    def __repr__(self):
+        s = ""
+        if self.partnumber:
+            s += f"{self.partnumber}"
+            if self.variant:
+                s += f"-{self.variant}"
+            if self.revision:
+                s += f" Rev{self.revision}"
+        return s

--- a/wasatch/AssemblyRevision.py
+++ b/wasatch/AssemblyRevision.py
@@ -1,4 +1,5 @@
 import json
+from . import utils
 
 class AssemblyRevision(dict):
     """
@@ -10,6 +11,9 @@ class AssemblyRevision(dict):
         self.partnumber = None
         self.variant = None
         self.revision = None
+
+        if isinstance(data, str):
+            data = utils.hex_string_to_data(data)
 
         self.parse_data(data)
 

--- a/wasatch/AutoRaman.py
+++ b/wasatch/AutoRaman.py
@@ -14,6 +14,15 @@ from . import utils
 
 log = logging.getLogger(__name__)
 
+class OptimizedAcquisitionParameters:
+    def __init__(self, int_time, gain_db, optimized_spectrum=None):
+        self.int_time = int_time
+        self.gain_db = gain_db
+
+        # if optimization was performed, save the final "optimal" sample for re-
+        # use in the averaged Raman spectrum
+        self.optimized_spectrum = optimized_spectrum
+
 class AutoRaman:
     """
     This class encapsulates Dieter's Auto-Raman algorithm, which optimizes 
@@ -24,6 +33,37 @@ class AutoRaman:
     As calling software will not necessarily expect the configured "default" 
     integration time and gain to change, the class restores those to previous
     levels after a measurement.
+
+    @par Auto-Collection mode
+
+    Auto-Collection mode was added to support STARVIS sensors with their
+    much-deeper dynamic range. Essentially this skips the "optimization"
+    step of balancing integration time and gain, and simply uses 
+    AutoRamanRequest.max_integ_ms. Gain is left at whatever is already 
+    configured.
+
+    @par InterfaceDevice handle
+
+    AutoRaman needs an InterfaceDevice to request spectra, fire the laser etc.
+    The provided InterfaceDevice should support the following features:
+
+    - device_id
+    - settings
+    - queue_message()
+    - check_alert()
+    - handle_requests()
+        - sensor
+            * get_spectrum([auto_raman_params])
+            * set_integration_time_ms
+            * set_detector_gain
+        - laser
+            * can_laser_fire
+            * is_laser_firing
+            * set_laser_enable
+            * get_laser_tec_mode
+            * get_ambient_temperature_degC
+            * get_laser_warning_delay_sec
+            * set_laser_warning_delay_sec
 
     @par Design Considerations
 
@@ -58,15 +98,16 @@ class AutoRaman:
 
     INTER_SPECTRA_DELAY_MS = 100
 
-    def __init__(self, wasatch_device):
-        self.wasatch_device = wasatch_device
+    def __init__(self, idevice, auto_collection_mode=False):
+        self.idevice = idevice
+        self.auto_collection_mode = auto_collection_mode
 
         self.progress_count = 0
         self.progress_total = 0
         self.optimizing = False
 
     def measure(self, auto_raman_request):
-        if auto_raman_request.onboard:
+        if auto_raman_request.onboard and not self.auto_collection_mode:
             return self.measure_firmware(auto_raman_request)
         else:
             return self.measure_software(auto_raman_request)
@@ -78,27 +119,26 @@ class AutoRaman:
     ############################################################################
 
     def measure_firmware(self, auto_raman_request):
-        hardware = self.wasatch_device.hardware
 
         # marshall the parameters into a binary payload
         params = auto_raman_request.serialize()
         log.debug(f"measure_firmware: params {utils.to_hex(params)}")
 
         # generate a request for FID to execute (note this could be a BLEDevice in the future)
-        req = SpectrometerRequest("get_line", kwargs={"auto_raman_params": params})
+        req = SpectrometerRequest("get_spectrum", kwargs={"auto_raman_params": params})
         log.debug(f"measure_firmware: req {req}")
 
         # perform the measurement -- all the work occurs here
-        hardware.queue_message("progress_bar", -1)
-        result = hardware.handle_requests([req])[0]
-        hardware.queue_message("progress_bar", 100)
+        self.idevice.queue_message("progress_bar", -1)
+        result = self.idevice.handle_requests([req])[0]
+        self.idevice.queue_message("progress_bar", 100)
 
         # process the result
         if result is None or isinstance(result, bool) or result.error_msg != '':
             raise(Exception(f"get_spectrum returned {result}"))
         spectrum = result.data.spectrum
 
-        reading = Reading(hardware.device_id)
+        reading = Reading(self.idevice.device_id)
         reading.spectrum                = np.array(spectrum)
         reading.dark                    = None
         reading.averaged                = True
@@ -106,8 +146,8 @@ class AutoRaman:
         reading.new_integration_time_ms = None      # todo: get_integration_time_ms()
         reading.new_gain_db             = None      # todo: get_detector_gain()
         reading.laser_enabled           = True
-        reading.laser_power_perc = hardware.settings.state.laser_power_perc
-        reading.laser_power_mW = hardware.settings.state.laser_power_mW
+        reading.laser_power_perc = self.idevice.settings.state.laser_power_perc
+        reading.laser_power_mW = self.idevice.settings.state.laser_power_mW
 
         # fill-out some otherwise missing attributes from WasatchDevice.acquire_spectrum_standard
         setting_to_attr = [ ('can_laser_fire',    'laser_can_fire'),
@@ -117,7 +157,7 @@ class AutoRaman:
                                       ('get_ambient_temperature_degC', 'ambient_temperature_degC') ] )
         for (setting, attr_name) in setting_to_attr:
             request = SpectrometerRequest(setting)
-            result = self.hardware.handle_requests([request])[0]
+            result = self.self.idevice.handle_requests([request])[0]
             if result is not None:
                 setattr(reading, attr_name, result.data)
 
@@ -146,8 +186,7 @@ class AutoRaman:
             log.error("measure requires AutoRamanRequest")
             return None
 
-        self.settings = self.wasatch_device.settings
-        self.hardware = self.wasatch_device.hardware
+        self.settings = self.idevice.settings
 
         self.optimizing = True
 
@@ -160,9 +199,16 @@ class AutoRaman:
 
         # apply requested laser warning delay
         if self.settings.is_xs():
-            self.hardware.set_laser_warning_delay_sec(auto_raman_request.laser_warning_delay_sec)
+            self.idevice.handle_requests([
+                SpectrometerRequest('set_laser_warning_delay_sec', args=[ 
+                    auto_raman_request.laser_warning_delay_sec 
+                ])
+            ])
 
+        ########################################################################
         # generate auto-Raman measurement
+        ########################################################################
+
         reading = self.get_auto_spectrum(auto_raman_request)
         if reading.spectrum is None:
             log.debug("looks like Auto-Raman measurement was cancelled")
@@ -170,21 +216,25 @@ class AutoRaman:
 
         # restore previous laser warning delay
         if self.settings.is_xs():
-            self.hardware.set_laser_warning_delay_sec(initial_laser_warning_delay_sec)
+            self.idevice.handle_requests([
+                SpectrometerRequest('set_laser_warning_delay_sec', args=[ 
+                    initial_laser_warning_delay_sec
+                ])
+            ])
 
         return SpectrometerResponse(data=reading)
 
     def bump_progress_bar(self):
         if self.optimizing:
-            self.hardware.queue_message("progress_bar", -1)
+            self.idevice.queue_message("progress_bar", -1)
         else:
             self.progress_count += 1
-            self.hardware.queue_message("progress_bar", 100 * (self.progress_count / self.progress_total))
+            self.idevice.queue_message("progress_bar", 100 * (self.progress_count / self.progress_total))
 
-    def get_avg_spectrum(self, int_time, gain_db, num_avg, throwaway=True, first=None, label="unknown"):
+    def get_avg_spectrum(self, int_time, gain_db, num_avg=1, throwaway=True, first=None, label="unknown"):
         """ Takes a single throwaway, then averages num_avg spectra """
 
-        if self.hardware.check_alert("auto_raman_cancel"):
+        if self.idevice.check_alert("auto_raman_cancel"):
             return
 
         self.set_integration_time_ms(int_time)
@@ -196,7 +246,7 @@ class AutoRaman:
             throwaway = self.get_spectrum()
             self.save(throwaway, f"{label} throwaway")
 
-        if self.hardware.check_alert("auto_raman_cancel"):
+        if self.idevice.check_alert("auto_raman_cancel"):
             return
 
         if first is None:
@@ -213,7 +263,7 @@ class AutoRaman:
             spectrum = np.array(self.get_spectrum())
             self.save(spectrum, f"{label} {i+1}/{num_avg}")
 
-            if self.hardware.check_alert("auto_raman_cancel"):
+            if self.idevice.check_alert("auto_raman_cancel"):
                 return
 
             sum_spectrum += spectrum
@@ -228,43 +278,44 @@ class AutoRaman:
                 now = datetime.now().strftime('%F %T.%f')[:-3]
                 values = ", ".join([f"{v:.2f}" for v in spectrum])
                 outfile.write(f"{now}, {label}, {values}\n")
-        
-    def get_auto_spectrum(self, request):
-        """
-        @returns a Reading with specturm, dark and sum_count populated
-        """
-        log.debug(f"get_auto_spectrum: start (max_ms {request.max_ms})")
 
-        reading = Reading(self.hardware.device_id)
-
-        int_time = request.start_integ_ms
-        gain_db = request.start_gain_db
-
-        gain_linear = self.from_db_to_linear(gain_db)
-        min_gain_linear = self.from_db_to_linear(request.min_gain_db)
-        max_gain_linear = self.from_db_to_linear(request.max_gain_db)
-
-        num_avg = 1
-
+    def enable_and_warmup_laser(self):
         # enable the laser and wait for it to fire
         self.set_laser_enable(True)
-        self.hardware.queue_message("laser_firing_indicators", "firing")
+        self.idevice.queue_message("laser_firing_indicators", "firing")
+
+        # arguably, we could use auto_raman_request.laser_warning_delay_sec here,
+        # not sure why we're re-reading what we just set in measure_software
         warning_delay_sec = self.get_laser_warning_delay_sec()
         if warning_delay_sec > 0:
-            self.hardware.queue_message("marquee_info", f"waiting {warning_delay_sec}sec for laser to fire")
+            self.idevice.queue_message("marquee_info", f"waiting {warning_delay_sec}sec for laser to fire")
             time.sleep(warning_delay_sec)
 
         laser_warmup_sec = self.settings.eeprom.laser_warmup_sec
         if laser_warmup_sec > 0:
-            self.hardware.queue_message("marquee_info", f"waiting {laser_warmup_sec}sec for laser to stabilize")
+            self.idevice.queue_message("marquee_info", f"waiting {laser_warmup_sec}sec for laser to stabilize")
             time.sleep(laser_warmup_sec)
 
-        # get one Raman spectrum to start (no dark)
+    def optimize_acquisition_parameters(self, request):
+        """ Assumes laser already enabled and warmed-up """
+
+        log.debug("optimizing acquisition parameters")
+
+        # starting point
+        int_time = request.start_integ_ms
+        gain_db = request.start_gain_db
+
+        # linearize gain scale
+        gain_linear = self.from_db_to_linear(gain_db)
+        min_gain_linear = self.from_db_to_linear(request.min_gain_db)
+        max_gain_linear = self.from_db_to_linear(request.max_gain_db)
+
+        # take initial Raman measurement with start params
         log.debug(f"taking initial spectrum (integ {int_time}, gain {gain_db})")
-        self.hardware.queue_message("marquee_info", "optimizing acquisition parameters")
-        spectrum = self.get_avg_spectrum(int_time, gain_db, num_avg=1, label="initial", throwaway=True)
+        self.idevice.queue_message("marquee_info", "optimizing acquisition parameters")
+        spectrum = self.get_avg_spectrum(int_time, gain_db, label="initial", throwaway=True)
         if spectrum is None:
-            return reading
+            return
 
         max_signal = spectrum.max()
 
@@ -304,14 +355,14 @@ class AutoRaman:
                     scale_factor = request.max_factor
                 
                 # increase int time first
-                log.debug(f"get_auto_spectrum: scaling int_time {int_time} UP by scale_factor {scale_factor:.2f}")
+                log.debug(f"optimize_acquisition_parameters: scaling int_time {int_time} UP by scale_factor {scale_factor:.2f}")
                 int_time *= scale_factor
 
                 # check int time does not exceed maximum
                 if int_time > request.max_integ_ms:
                     # however much int time exceeds the max, transfer scaling to gain
                     gain_factor = int_time / request.max_integ_ms
-                    log.debug(f"get_auto_spectrum: scaling gain_linear {gain_linear} UP by gain_factor {gain_factor:.2f}")
+                    log.debug(f"optimize_acquisition_parameters: scaling gain_linear {gain_linear} UP by gain_factor {gain_factor:.2f}")
                     gain_linear *= gain_factor
                     int_time = request.max_integ_ms
 
@@ -322,14 +373,14 @@ class AutoRaman:
                     scale_factor = request.drop_factor
 
                 # decrease gain first (INCREASE int time first implies DECREASE int time last)
-                log.debug(f"get_auto_spectrum: scaling gain_linear {gain_linear:.2f} DOWN by scale_factor {scale_factor:.2f}")
+                log.debug(f"optimize_acquisition_parameters: scaling gain_linear {gain_linear:.2f} DOWN by scale_factor {scale_factor:.2f}")
                 gain_linear *= scale_factor
 
                 # check we did not drop below min gain
                 if gain_linear < min_gain_linear:
                     # dump the overshoot into decreasing int time
                     int_factor = gain_linear / min_gain_linear
-                    log.debug(f"get_auto_spectrum: scaling int_time {int_time} DOWN by int_factor {int_factor:.2f}")
+                    log.debug(f"optimize_acquisition_parameters: scaling int_time {int_time} DOWN by int_factor {int_factor:.2f}")
                     int_time *= int_factor
                     gain_linear = min_gain_linear
 
@@ -368,54 +419,102 @@ class AutoRaman:
                         else:
                             quit_loop = True
 
-            log.debug(f"integ now {int_time}, gain now {gain_db:.1f} (linear {gain_linear:.4f})")
+            log.debug(f"optimize_acquisition_parameters: integ now {int_time}, gain now {gain_db:.1f} (linear {gain_linear:.4f})")
 
-            log.debug(f"Taking spectrum #{loop_count}")
-            self.hardware.queue_message("marquee_info", "optimizing acquisition parameters")
-            spectrum = self.get_avg_spectrum(int_time, gain_db, num_avg=1, label="optimizing", throwaway=True)
+            log.debug(f"optimize_acquisition_parameters: Taking spectrum #{loop_count}")
+            self.idevice.queue_message("marquee_info", "optimizing acquisition parameters")
+            spectrum = self.get_avg_spectrum(int_time, gain_db, label="optimizing", throwaway=True)
             if spectrum is None:
-                return reading
+                return
 
             max_signal = spectrum.max()
 
             if max_signal < request.max_counts and max_signal > request.min_counts:
-                log.debug(f"===> achieved window (max_signal {max_signal} in range ({request.min_counts}, {request.max_counts}))")
+                log.debug(f"optimize_acquisition_parameters: ===> achieved window (max_signal {max_signal} in range ({request.min_counts}, {request.max_counts}))")
                 quit_loop = True
             elif max_signal < request.min_counts and int_time >= request.max_integ_ms and gain_db >= request.max_gain_db:
-                log.debug("can't achieve window within acquisition parameter limits")
+                log.debug("optimize_acquisition_parameters: can't achieve window within acquisition parameter limits")
                 quit_loop = True
+        
+        return OptimizedAcquisitionParameters(int_time=int_time, gain_db=gain_db, optimized_spectrum=spectrum)
+
+    def get_auto_spectrum(self, request):
+        """
+        This is the "Auto-Raman algorithm." Everything that matters happens here.
+
+        @returns a Reading with spectrum, dark and sum_count populated
+        """
+        log.debug(f"get_auto_spectrum: start (max_ms {request.max_ms})")
+
+        reading = Reading(self.idevice.device_id)
+
+        ########################################################################
+        # Optimize Acquisition Parameters
+        ########################################################################
+
+        self.enable_and_warmup_laser()
+
+        if self.auto_collection_mode:
+            opt_params = OptimizedAcquisitionParameters(int_time = request.max_integ_ms, 
+                                                        gain_db  = device.settings.state.gain_db)
+        else:
+            opt_params = self.optimize_acquisition_parameters(request)
+            if not opt_params:
+                log.error("unable to optimize acquisition parameters")
+                return reading
+
+        ########################################################################
+        # Generate Measurement Plan
+        ########################################################################
 
         # decide on number of averages - all times in ms
         # include dark + signal
 
         self.optimizing = False
-        total = math.floor(request.max_ms / int_time)   # total number of sample + dark spectra we have time for
+        total = math.floor(request.max_ms / opt_params.int_time)   # total number of sample + dark spectra we have time for
         num_avg = math.ceil((total + 1) / 2)            # how many darks to collect
         num_avg = max(1, num_avg)
         num_avg = min(num_avg, request.max_avg)
         self.progress_count = 0
         self.progress_total = 2 * num_avg - 1           # darks + remaining samples
-        expected_ms = int_time * self.progress_total 
-        log.debug(f"based on max_ms {request.max_ms} and int_time {int_time} ms, computed num_avg {num_avg} (expected_ms {expected_ms})")
+        expected_ms = opt_params.int_time * self.progress_total 
+        log.debug(f"based on max_ms {request.max_ms} and int_time {opt_params.int_time} ms, computed num_avg {num_avg} (expected_ms {expected_ms})")
+
+        ########################################################################
+        # collect remaining Raman samples
+        ########################################################################
 
         # now get the spectrum with the chosen parameters
         # take two averaged spectra here: avg signal first, then turn laser off, then take dark
         # (this saves the laser warm up)
 
         # 1. signal - laser is still on
-        self.hardware.queue_message("marquee_info", f"averaging {num_avg} Raman spectra at {int_time}ms")
-        avg_sample = self.get_avg_spectrum(int_time, gain_db, num_avg, throwaway=False, first=spectrum, label="signal")
+        self.idevice.queue_message("marquee_info", f"averaging {num_avg} Raman spectra at {opt_params.int_time}ms")
+        avg_sample = self.get_avg_spectrum(opt_params.int_time, 
+                                           opt_params.gain_db, 
+                                           num_avg=num_avg, 
+                                           throwaway=False, 
+                                           first=opt_params.optimized_spectrum, 
+                                           label="signal")
         if avg_sample is None:
             return reading
         self.save(avg_sample, "averaged sample")
 
+        ########################################################################
+        # collect darks
+        ########################################################################
+
         # 2. turn laser off
         self.set_laser_enable(False)
-        self.hardware.queue_message("laser_firing_indicators", "not firing")
+        self.idevice.queue_message("laser_firing_indicators", "not firing")
 
         # 3. take dark
-        self.hardware.queue_message("marquee_info", f"averaging {num_avg} dark spectra at {int_time}ms")
-        avg_dark = self.get_avg_spectrum(int_time, gain_db, num_avg, throwaway=True, label="dark")
+        self.idevice.queue_message("marquee_info", f"averaging {num_avg} dark spectra at {opt_params.int_time}ms")
+        avg_dark = self.get_avg_spectrum(opt_params.int_time, 
+                                         opt_params.gain_db, 
+                                         num_avg=num_avg, 
+                                         throwaway=True, 
+                                         label="dark")
         if avg_dark is None:
             return reading
         self.save(avg_dark, "averaged dark")
@@ -428,11 +527,15 @@ class AutoRaman:
         reading.dark = avg_dark
         reading.averaged = True
         reading.sum_count = num_avg
-        reading.new_integration_time_ms = int_time
-        reading.new_gain_db = gain_db
+        reading.new_integration_time_ms = opt_params.int_time
+        reading.new_gain_db = opt_params.gain_db
         reading.laser_enabled = True
-        reading.laser_power_perc = self.hardware.settings.state.laser_power_perc
-        reading.laser_power_mW = self.hardware.settings.state.laser_power_mW
+        reading.laser_power_perc = self.idevice.settings.state.laser_power_perc
+        reading.laser_power_mW = self.idevice.settings.state.laser_power_mW
+
+        ########################################################################
+        # fill-in miscellaneous spectrometer state
+        ########################################################################
 
         # fill-out some otherwise missing attributes from WasatchDevice.acquire_spectrum_standard
         setting_to_attr = [ ('can_laser_fire',    'laser_can_fire'),
@@ -442,8 +545,8 @@ class AutoRaman:
                                       ('get_ambient_temperature_degC', 'ambient_temperature_degC') ] )
         for (setting, attr_name) in setting_to_attr:
             request = SpectrometerRequest(setting)
-            result = self.hardware.handle_requests([request])[0]
-            if result is not None:
+            result = self.idevice.handle_requests([request])[0]
+            if result is not None and not result.error_msg:
                 setattr(reading, attr_name, result.data)
 
         log.debug("done")
@@ -454,26 +557,26 @@ class AutoRaman:
     ############################################################################
 
     def get_laser_warning_delay_sec(self):
-        response = self.hardware.handle_requests([SpectrometerRequest('get_laser_warning_delay_sec')])[0]
+        response = self.idevice.handle_requests([SpectrometerRequest('get_laser_warning_delay_sec')])[0]
         log.debug(f"get_laser_warning_delay_sec: response {response}")
         if response is None or response.data is None:
             return 5
         return response.data
 
     def set_laser_enable(self, flag):
-        self.hardware.handle_requests([SpectrometerRequest('set_laser_enable', args=[flag])])
+        self.idevice.handle_requests([SpectrometerRequest('set_laser_enable', args=[flag])])
 
     def set_integration_time_ms(self, ms):
         if ms != self.settings.state.integration_time_ms:
-            self.hardware.handle_requests([SpectrometerRequest('set_integration_time_ms', args=[ms])])
+            self.idevice.handle_requests([SpectrometerRequest('set_integration_time_ms', args=[ms])])
 
     def set_gain_db(self, db):
         if self.settings.is_xs():
             if abs(db - self.settings.state.gain_db) > 0.05:
-                self.hardware.handle_requests([SpectrometerRequest('set_detector_gain', args=[db])])
+                self.idevice.handle_requests([SpectrometerRequest('set_detector_gain', args=[db])])
 
     def get_spectrum(self):
-        result = self.hardware.handle_requests([SpectrometerRequest("get_line")])[0]
+        result = self.idevice.handle_requests([SpectrometerRequest("get_spectrum")])[0]
         if result is None or isinstance(result, bool) or result.error_msg != '':
             raise(Exception(f"get_spectrum returned {result}"))
         spectrum = result.data.spectrum

--- a/wasatch/BLEDevice.py
+++ b/wasatch/BLEDevice.py
@@ -247,9 +247,11 @@ class BLEDevice(InterfaceDevice):
 
     CONNECT_TIMEOUT_SEC = 10
 
-    MAX_EEPROM_PAGES = 8 # separate from EEPROMFields, as XS BLE FW may not be in sync
+    # separate from EEPROMFields, as XS BLE FW may not be in sync
+    MAX_EEPROM_PAGES = 8 
 
-    STATUS_UPDATE_PERIOD_SEC = 60 # update Ambient temperature etc via acquire_data
+    # update Ambient temperature etc via acquire_data
+    STATUS_UPDATE_PERIOD_SEC = 60 
 
     LASER_TEC_MODES = {
         0: 'OFF', 
@@ -292,11 +294,7 @@ class BLEDevice(InterfaceDevice):
     }
 
     def __init__(self, device_id, message_queue=None, alert_queue=None):
-        super().__init__()
-
-        self.device_id      = device_id
-        self.message_queue  = message_queue
-        self.alert_queue    = alert_queue
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
         # all Characteristics to which we're subscribed for notifications
         self.notifications = set() 

--- a/wasatch/BLEDevice.py
+++ b/wasatch/BLEDevice.py
@@ -340,6 +340,8 @@ class BLEDevice(InterfaceDevice):
 
         self.testing = False
         self.last_status_update_time = None
+        self.next_laser_enable = False
+        self.next_laser_power_perc = 100
         
         # ability to bridge sync-async
         self.run_loop = self.get_run_loop()
@@ -886,6 +888,7 @@ class BLEDevice(InterfaceDevice):
     ############################################################################
 
     async def laser_state_notification_async(self, sender, data):
+        log.debug(f"received laser_state_notification: data {data}")
         await self.update_laser_state_from_device_async(data)
 
     def update_laser_state_from_device(self, arg=None):
@@ -898,6 +901,7 @@ class BLEDevice(InterfaceDevice):
         if buf is None:
             return
 
+        # note that we're reading these into SpectrometerState, not self.next_FOO
         state = self.settings.state
 
         if len(buf) >= 4:
@@ -925,26 +929,25 @@ class BLEDevice(InterfaceDevice):
         return SpectrometerResponse(future.result())
     async def set_laser_enable_async(self, flag):
         log.debug(f"setting laser enable {flag}")
-        self.settings.state.laser_enable = flag
+        self.next_laser_enable = flag
         await self.sync_laser_state_to_device_async()
 
     async def sync_laser_state_to_device_async(self):
         log.debug(f"sync_laser_state_to_device_async: start")
 
-        state = self.settings.state
+        pwm_perc = int(min(100, self.next_laser_power_perc)) & 0xff
 
-        # note that we're reading these values from SELF (not STATE) -> DEVICE
-        data = [ 0xff,                    # 0: mode (NO CHANGE)
-                 0xff,                    # 1: type (NO CHANGE)
-                 0x01 if state.laser_enable else 0x00,  # 2: enable
+        data = [ 0x00,                    # 0: mode (reserved)
+                 0x00,                    # 1: type (reserved)
+                 0x01 if self.next_laser_enable else 0x00, # 2: enable
                  0xff,                    # 3: laser watchdog (NO CHANGE)
                  0xff,                    # 4: laser watchdog (NO CHANGE)
                  0x00,                    # 5: reserved (legacy laser_warning_delay_ms)
                  0x00,                    # 6: reserved (legacy laser_warning_delay_ms)
                  0xff,                    # 7: read-only status_mask (laser_can_fire, laser_is_firing etc)
-                 state.laser_power_perc ] # 8: laser PWM
+                 pwm_perc ]               # 8: laser PWM
 
-        log.debug(f"sync_laser_state_to_device_asyhc: calling write_char_async('LASER_STATE') with data {data}")
+        log.debug(f"sync_laser_state_to_device_async: calling write_char_async('LASER_STATE') with data {data}")
         await self.write_char_async("LASER_STATE", data)
         log.debug(f"sync_laser_state_to_device_async: done")
 
@@ -953,7 +956,7 @@ class BLEDevice(InterfaceDevice):
         return SpectrometerResponse(future.result())
     async def set_laser_power_perc_async(self, perc):
         log.debug(f"setting laser power perc {perc}")
-        self.laser_power_perc = perc 
+        self.next_laser_power_perc = perc 
         await self.sync_laser_state_to_device_async()
 
     ############################################################################

--- a/wasatch/BLEDevice.py
+++ b/wasatch/BLEDevice.py
@@ -403,10 +403,10 @@ class BLEDevice(InterfaceDevice):
         self.settings.update_wavecal()
 
         log.debug(f"connect_async: initializing LASER_STATE")
-        await self.update_laser_state_async()
+        await self.update_laser_state_from_device_async()
 
         log.debug(f"connect_async: initializing BATTERY_STATE")
-        await self.update_battery_state_async()
+        await self.update_battery_state_from_device_async()
 
         log.debug(f"connect_async: initializing integration time")
         self.integration_time_ms = self.settings.eeprom.startup_integration_time_ms
@@ -851,12 +851,12 @@ class BLEDevice(InterfaceDevice):
     ############################################################################
 
     async def battery_notification_async(self, sender, data):
-        await self.update_battery_state_async(data)
+        await self.update_battery_state_from_device_async(data)
 
-    def update_battery_state(self, arg=None):
-        future = asyncio.run_coroutine_threadsafe(self.update_battery_state_async(), self.run_loop)
+    def update_battery_state_from_device(self, arg=None):
+        future = asyncio.run_coroutine_threadsafe(self.update_battery_state_from_device_async(), self.run_loop)
         return SpectrometerResponse(future.result())
-    async def update_battery_state_async(self, buf=None):
+    async def update_battery_state_from_device_async(self, buf=None):
         """
         These will be pushed automatically 2/min from Central, if-and-only-if
         no acquisition is occuring at the time of the scheduled event. However,
@@ -886,12 +886,12 @@ class BLEDevice(InterfaceDevice):
     ############################################################################
 
     async def laser_state_notification_async(self, sender, data):
-        await self.update_laser_state_async(data)
+        await self.update_laser_state_from_device_async(data)
 
-    def update_laser_state(self, arg=None):
-        future = asyncio.run_coroutine_threadsafe(self.update_laser_state_async(), self.run_loop)
+    def update_laser_state_from_device(self, arg=None):
+        future = asyncio.run_coroutine_threadsafe(self.update_laser_state_from_device_async(), self.run_loop)
         return SpectrometerResponse(future.result())
-    async def update_laser_state_async(self, buf=None):
+    async def update_laser_state_from_device_async(self, buf=None):
         if buf is None:
             log.debug("updating laser state")
             buf = await self.read_char_async("LASER_STATE", 7)
@@ -912,35 +912,49 @@ class BLEDevice(InterfaceDevice):
             state.laser_is_firing = buf[7] & 0x02
 
         if len(buf) >= 9: 
-            state.laser_pwm_perc = buf[8]
+            state.laser_power_perc = buf[8]
 
         log.debug(f"updated laser state: enabled {state.laser_enabled}, " +
                   f"watchdog {state.laser_watchdog_sec}sec, " +
                   f"can_fire {state.laser_can_fire}, " +
                   f"is_firing {state.laser_is_firing}, " + 
-                  f"PWM {state.laser_pwm_perc}")
+                  f"PWM {state.laser_power_perc}")
 
     def set_laser_enable(self, flag):
         future = asyncio.run_coroutine_threadsafe(self.set_laser_enable_async(flag), self.run_loop)
         return SpectrometerResponse(future.result())
     async def set_laser_enable_async(self, flag):
         log.debug(f"setting laser enable {flag}")
-        self.laser_enable = flag
-        await self.sync_laser_state_async()
+        self.settings.state.laser_enable = flag
+        await self.sync_laser_state_to_device_async()
 
-    async def sync_laser_state_async(self):
-        log.debug(f"sync_laser_state_async: start")
+    async def sync_laser_state_to_device_async(self):
+        log.debug(f"sync_laser_state_to_device_async: start")
 
-        data = [ 0xff,                   # mode (NO CHANGE)
-                 0xff,                   # type (NO CHANGE)
-                 0x01 if self.laser_enable else 0x00, 
-                 0xff,                   # laser watchdog (NO CHANGE)
-                 0x00,                   # reserved (legacy laser_warning_delay_ms)
-                 0x00 ]                  # reserved (legacy laser_warning_delay_ms)
+        state = self.settings.state
 
-        log.debug(f"sync_laser_state_asyhc: calling write_char_async('LASER_STATE') with data {data}")
+        # note that we're reading these values from SELF (not STATE) -> DEVICE
+        data = [ 0xff,                    # 0: mode (NO CHANGE)
+                 0xff,                    # 1: type (NO CHANGE)
+                 0x01 if state.laser_enable else 0x00,  # 2: enable
+                 0xff,                    # 3: laser watchdog (NO CHANGE)
+                 0xff,                    # 4: laser watchdog (NO CHANGE)
+                 0x00,                    # 5: reserved (legacy laser_warning_delay_ms)
+                 0x00,                    # 6: reserved (legacy laser_warning_delay_ms)
+                 0xff,                    # 7: read-only status_mask (laser_can_fire, laser_is_firing etc)
+                 state.laser_power_perc ] # 8: laser PWM
+
+        log.debug(f"sync_laser_state_to_device_asyhc: calling write_char_async('LASER_STATE') with data {data}")
         await self.write_char_async("LASER_STATE", data)
-        log.debug(f"sync_laser_state_async: done")
+        log.debug(f"sync_laser_state_to_device_async: done")
+
+    def set_laser_power_perc(self, perc):
+        future = asyncio.run_coroutine_threadsafe(self.set_laser_power_perc_async(perc), self.run_loop)
+        return SpectrometerResponse(future.result())
+    async def set_laser_power_perc_async(self, perc):
+        log.debug(f"setting laser power perc {perc}")
+        self.laser_power_perc = perc 
+        await self.sync_laser_state_to_device_async()
 
     ############################################################################
     # ACQUIRE and SPECTRA Characteristics
@@ -1134,8 +1148,8 @@ class BLEDevice(InterfaceDevice):
         this lets software drive (and initialize) that loop directly. Also, we 
         can add non-"urgent" attributes like ambient temperature, etc.
         """
-        await self.update_battery_state_async()
-        await self.update_laser_state_async()
+        await self.update_battery_state_from_device_async()
+        await self.update_laser_state_from_device_async()
         await self.get_ambient_temperature_deg_c_async()
         await self.get_power_connection_state_async()
 
@@ -1196,6 +1210,9 @@ class BLEDevice(InterfaceDevice):
         f["get_image_sensor_state"]  = self.get_image_sensor_state
         f["update_status"]           = self.update_status
         f["vertical_binning"]        = self.set_vertical_roi
+        f["laser_power_perc"]        = self.set_laser_power_perc
+        f["laser_power_mW"]          = None
+        f["laser_power_require_modulation"] = None
         return f
 
     ############################################################################

--- a/wasatch/CSVLoader.py
+++ b/wasatch/CSVLoader.py
@@ -180,9 +180,8 @@ class CSVLoader:
         # clear any arrays we ended up not filling
         self.processed_reading.post_load_cleanup()
 
-        log.debug("returning processed_reading:")
-        self.processed_reading.dump()
-
-        log.debug(f"returning metadata {self.metadata}")
+        # log.debug("returning processed_reading:")
+        # self.processed_reading.dump()
+        # log.debug(f"returning metadata {self.metadata}")
 
         return self.processed_reading, self.metadata

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import struct
+import numpy as np
 import array
 import copy
 import json
@@ -954,12 +955,18 @@ class EEPROM:
                 else:
                     buf[start_byte + i] = 0
         elif data_type == "*":
-            # non-standard extension
             for i in range(start_byte, end_byte):
                 buf[i] = 0
-            if value is not None:
+            if isinstance(value, str):
+                value = value.removeprefix("0x")
+                new_value = []
+                for i in range(len(value) // 2):
+                    b = value[i*2:i*2+2]
+                    new_value.append(int(b, 16))
+                value = new_value
+            if isinstance(value, list):
                 for i in range(min(length, len(value))):
-                    buf[i] = value[i]
+                    buf[start_byte + i] = value[i]
         else:
             if data_type == "f":
                 value = float(value)
@@ -1015,7 +1022,7 @@ class EEPROM:
         # this does take an allow_nan argument, but it throws an exception on NaN, 
         # rather than replacing with null :-(
         # https://stackoverflow.com/questions/6601812/sending-nan-in-json
-        s = json.dumps(self.__dict__, indent=2, sort_keys=True)
+        s = json.dumps(self.__dict__, indent=2, sort_keys=True, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else None)
         if not allow_nan:
             s = re.sub(r"\bNaN\b", "null", s)
 

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -1114,7 +1114,7 @@ class EEPROM:
         log.debug("  ROI Vert Reg 3:   (%d, %d)", self.roi_vertical_region_3_start, self.roi_vertical_region_3_end)
        #log.debug("  Linearity Coeffs: %s", self.linearity_coeffs) # deprecated
         log.debug("")
-        log.debug("  Max Laser Temp:   %d degC", self.max_laser_temp_deg_c)
+        log.debug("  Max Laser Temp:   %s", f"{self.max_laser_temp_deg_c} degC" if self.max_laser_temp_deg_c is not None else None)
         log.debug("  Laser coeffs:     %s", self.laser_power_coeffs)
         log.debug("  Max Laser Power:  %s mW", self.max_laser_power_mW)
         log.debug("  Min Laser Power:  %s mW", self.min_laser_power_mW)

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -55,7 +55,9 @@ class EEPROM:
         ((0, 52,  2), "h", "detector_offset"), 
         ((0, 54,  4), "f", "detector_gain_odd"), 
         ((0, 58,  2), "h", "detector_offset_odd"), 
+        ((0, 60,  2), "h", "startup_laser_tec_setpoint"), 
         ((0, 63,  1), "B", "format"), 
+
         ((1,  0,  4), "f", "wavecal_c0"),
         ((1,  4,  4), "f", "wavecal_c1"),
         ((1,  8,  4), "f", "wavecal_c2"),
@@ -105,19 +107,30 @@ class EEPROM:
         ((3, 44,  4), "I", "max_integration_time_ms"),
         ((3, 48,  4), "f", "avg_resolution"),
         ((3, 52,  2), "H", "laser_watchdog_sec"),
+        ((3, 54,  1), "B", "light_source_type"),
         ((3, 55,  2), "H", "power_timeout_sec"),
         ((3, 57,  2), "H", "detector_timeout_sec"),
         ((3, 59,  1), "B", "horiz_binning_mode"),
         ((3, 60,  1), "B", "startup_scans_to_average"),
         ((3, 61,  1), "B", "laser_attenuator"),
 
-        ((4,  0, 64), "s", "user_data"),
+        ((4,  0, 64), "*", "user_data"),
 
         ((5, 30, 16), "s", "product_configuration"),
         ((5, 45,  6), "*", "assembly_revision_packed"),
         ((5, 63,  1), "B", "subformat"),
 
         ((8,  0, 15), "s", "laser_password"),
+        ((8, 16,  4), "I", "feature_mask_xs"),
+        ((8, 20,  2), "H", "acc_state"),
+        ((8, 22,  1), "B", "acc_state_gpio1"),
+        ((8, 23,  1), "B", "acc_state_gpio2"),
+        ((8, 24,  4), "I", "acc_cont_strobe_period_us"),
+        ((8, 28,  4), "I", "acc_cont_strobe_width_us"),
+        ((8, 32,  4), "I", "acc_cont_strobe_delay_us"),
+        ((8, 36,  2), "H", "acc_cont_strobe_count"),
+        ((8, 38,  1), "b", "max_battery_temp_deg_c"),
+        ((8, 39,  1), "b", "pixel_calibration_type"),
     ]
 
     def __init__(self):
@@ -206,6 +219,16 @@ class EEPROM:
         self.assembly_revision           = None
 
         self.laser_password              = None
+        self.feature_mask_xs             = None
+        self.acc_state                   = None
+        self.acc_state_gpio1             = None
+        self.acc_state_gpio2             = None
+        self.acc_cont_strobe_period_us   = None
+        self.acc_cont_strobe_width_us    = None
+        self.acc_cont_strobe_delay_us    = None
+        self.acc_cont_strobe_count       = None
+        self.max_battery_temp_deg_c      = None
+        self.pixel_calibration_type      = None
 
         self.format                      = EEPROM.LATEST_REV
         self.subformat                   = 0 # determines format of pages 6-7
@@ -338,21 +361,18 @@ class EEPROM:
     # @see https://docs.python.org/2/library/struct.html#format-characters
     # (capitals are unsigned)
     def read_eeprom(self):
-        self.format = self.unpack((0, 63,  1), "B", "format")
+        self.unpack_field("format")
         log.debug("parsing EEPROM format %d", self.format)
 
         # ######################################################################
         # Page 0
         # ######################################################################
 
-        self.model                           = self.unpack((0,  0, 16), "s", "model")
-        self.serial_number                   = self.unpack((0, 16, 16), "s", "serial")
-        self.baud_rate                       = 0 # self.unpack((0, 32,  4), "I", "baud") # deprecated
-        self.has_cooling                     = self.unpack((0, 36,  1), "?", "cooling")
-        self.has_battery                     = self.unpack((0, 37,  1), "?", "battery")
-        self.has_laser                       = self.unpack((0, 38,  1), "?", "laser")
+        for name in [ "model", "serial_number", "has_cooling", "has_battery", "has_laser" ]:
+            self.unpack_field(name)
+
         if self.format > 9:
-            self.feature_mask                = self.unpack((0, 39,  2), "H", "feature_mask")
+            self.unpack_field("feature_mask")
         elif self.format >= 3:
             self.excitation_nm               = self.unpack((0, 39,  2), "H", "excitation_nm (unsigned)")
         else:
@@ -367,16 +387,13 @@ class EEPROM:
         #       EEPROM until we start bumping production spectrometers to
         #       EEPROM Page 0 Revision 3!
         if self.format >= 3:
-            self.startup_integration_time_ms = self.unpack((0, 43,  2), "H", "startup_integration_time_ms")
-            self.startup_temp_degC           = self.unpack((0, 45,  2), "h", "startup_temp_degC")
-            self.startup_triggering_scheme   = self.unpack((0, 47,  1), "B", "startup_triggering_scheme")
-            self.detector_gain               = self.unpack((0, 48,  4), "f", "detector_gain") # "even pixels" for InGaAs
-            self.detector_offset             = self.unpack((0, 52,  2), "h", "detector_offset") # "even pixels" for InGaAs
-            self.detector_gain_odd           = self.unpack((0, 54,  4), "f", "detector_gain_odd") # InGaAs-only
-            self.detector_offset_odd         = self.unpack((0, 58,  2), "h", "detector_offset_odd") # InGaAs-only
+            for name in [ "startup_integration_time_ms", "startup_temp_degC", "startup_triggering_scheme",
+                          "detector_gain", "detector_offset", "detector_gain_odd", "detector_offset_odd" ]:
+                self.unpack_field(name)
 
         if self.format >= 16:
-            self.startup_laser_tec_setpoint  = self.unpack((0, 60,  2), "H", "startup_laser_tec_setpoint") & 0xfff # XS-only
+            self.unpack_field("startup_laser_tec_setpoint")
+            self.startup_laser_tec_setpoint &= 0xfff
 
         # ######################################################################
         # Page 1
@@ -406,10 +423,12 @@ class EEPROM:
         # Page 2                    
         # ######################################################################
 
-        self.detector                        = self.unpack((2,  0, 16), "s", "detector")
-        self.active_pixels_horizontal        = self.unpack((2, 16,  2), "H", "active_pixels_horizontal")
+        for name in [ "detector", "active_pixels_horizontal" ]:
+            self.unpack_field(name)
+
         if self.format >= 10:
-            self.laser_warmup_sec            = self.unpack((2, 18,  1), "B", "laser_warmup_sec")
+            self.unpack_field("laser_warmup_sec")
+
         self.active_pixels_vertical          = self.unpack((2, 19,  2), "H" if self.format >= 4 else "h")
 
         if self.format >= 8:
@@ -432,12 +451,6 @@ class EEPROM:
         self.roi_vertical_region_3_start     = self.unpack((2, 39,  2), "H" if self.format >= 4 else "h")
         self.roi_vertical_region_3_end       = self.unpack((2, 41,  2), "H" if self.format >= 4 else "h")
         self.linearity_coeffs = []
-        if False: # deprecated
-            self.linearity_coeffs          .append(self.unpack((2, 43,  4), "f", "linearity_coeff_0")) # overloading for secondary ADC
-            self.linearity_coeffs          .append(self.unpack((2, 47,  4), "f"))
-            self.linearity_coeffs          .append(self.unpack((2, 51,  4), "f"))
-            self.linearity_coeffs          .append(self.unpack((2, 55,  4), "f"))
-            self.linearity_coeffs          .append(self.unpack((2, 59,  4), "f"))
 
         # ######################################################################
         # Page 3
@@ -455,25 +468,25 @@ class EEPROM:
         self.min_laser_power_mW              = self.unpack((3, 32,  4), "f", "min_laser_power_mW")
 
         if self.format >= 4:
-            self.excitation_nm_float         = self.unpack((3, 36,  4), "f", "excitation(float)")
+            self.unpack_field("excitation_nm_float")
         else:
             self.excitation_nm_float = self.excitation_nm
 
         if self.format >= 5:
-            self.min_integration_time_ms     = self.unpack((3, 40,  4), "I", "min_integration_time_ms")
-            self.max_integration_time_ms     = self.unpack((3, 44,  4), "I", "max_integration_time_ms")
+            self.unpack_field("min_integration_time_ms")
+            self.unpack_field("max_integration_time_ms")
 
         if self.format >= 7:
-            self.avg_resolution              = self.unpack((3, 48,  4), "f", "avg_resolution")
+            self.unpack_field("avg_resolution")
 
         if self.format >= 15:
-            self.laser_watchdog_sec          = self.unpack((3, 52,  2), "H", "laser_watchdog_sec")
-            self.light_source_type           = self.unpack((3, 54,  1), "B", "light_source_type")
+            self.unpack_field("laser_watchdog_sec")
+            self.unpack_field("light_source_type")
 
         if self.format >= 16:
-            self.power_timeout_sec           = self.unpack((3, 55,  2), "H", "power_timeout_sec")
-            self.detector_timeout_sec        = self.unpack((3, 57,  2), "H", "detector_timeout_sec")
-            self.horiz_binning_mode          = self.unpack((3, 59,  1), "B", "horiz_binning_mode")
+            self.unpack_field("power_timeout_sec")
+            self.unpack_field("detector_timeout_sec")
+            self.unpack_field("horiz_binning_mode")
 
         if self.format >= 18:
             self.unpack_field("startup_scans_to_average")
@@ -499,12 +512,12 @@ class EEPROM:
         self.bad_pixels.sort()
 
         if self.format >= 5:
-            self.product_configuration       = self.unpack((5,  30, 16), "s", "product_configuration")
+            self.unpack_field("product_configuration")
         if self.format >= 18:
             self.unpack_field("assembly_revision_packed")
             self.assembly_revision = AssemblyRevision(self.assembly_revision_packed)
         if self.format >= 7:
-            self.subformat                   = self.unpack((5,  63,  1), "B", "subformat")
+            self.unpack_field("subformat")
 
         # ######################################################################
         # Page 6-7
@@ -572,6 +585,13 @@ class EEPROM:
             elif len(s) < 4 or any([not (31 < ord(c) < 128) for c in s]):
                 log.debug("no valid laser password found")
                 self.laser_password = None
+
+            for name in [ "feature_mask_xs", "acc_state", 
+                          "acc_state_gpio1", "acc_state_gpio2", 
+                          "acc_cont_strobe_period_us", "acc_cont_strobe_width_us", 
+                          "acc_cont_strobe_delay_us", "acc_cont_strobe_count", 
+                          "max_battery_temp_deg_c", "pixel_calibration_type" ]:
+                self.unpack_field(name)
 
         # ######################################################################
         # sanity checks
@@ -653,22 +673,15 @@ class EEPROM:
         # Page 0
         # ######################################################################
 
-        self.pack((0,  0, 16), "s", self.model)
-        self.pack((0, 16, 16), "s", self.serial_number)
-        self.pack((0, 32,  4), "I", self.baud_rate) # deprecated (zero)
-        self.pack((0, 36,  1), "?", self.has_cooling)
-        self.pack((0, 37,  1), "?", self.has_battery)
-        self.pack((0, 38,  1), "?", self.has_laser)
+        for name in [ "model", "serial_number", 
+                      "has_cooling", "has_battery", "has_laser", 
+                      "slit_size_um", "startup_integration_time_ms",
+                      "startup_temp_degC", "startup_triggering_scheme", 
+                      "detector_gain", "detector_offset", "detector_gain_odd", "detector_offset_odd", 
+                      "startup_laser_tec_setpoint"]:
+            self.pack_field(name)
+
         self.pack((0, 39,  2), "H", self.generate_feature_mask(), "FeatureMask")
-        self.pack((0, 41,  2), "H", self.slit_size_um)
-        self.pack((0, 43,  2), "H", self.startup_integration_time_ms)
-        self.pack((0, 45,  2), "h", self.startup_temp_degC)
-        self.pack((0, 47,  1), "B", self.startup_triggering_scheme)
-        self.pack((0, 48,  4), "f", self.detector_gain)
-        self.pack((0, 52,  2), "h", self.detector_offset)
-        self.pack((0, 54,  4), "f", self.detector_gain_odd)
-        self.pack((0, 58,  2), "h", self.detector_offset_odd)
-        self.pack((0, 60,  2), "H", self.startup_laser_tec_setpoint)
 
         # ######################################################################
         # Page 1
@@ -687,44 +700,33 @@ class EEPROM:
             for i in range(min(3, len(self.adc_to_degC_coeffs))):
                 self.pack((1, 32 + i * 4,  4), "f", self.adc_to_degC_coeffs[i])
 
-        self.pack((1, 28,  2), "h", self.max_temp_degC)
-        self.pack((1, 30,  2), "h", self.min_temp_degC)
-        self.pack((1, 44,  2), "h", self.tec_r298)
-        self.pack((1, 46,  2), "h", self.tec_beta)
-        self.pack((1, 48, 12), "s", self.calibration_date)
-        self.pack((1, 60,  3), "s", self.calibrated_by)
+        for name in [ "max_temp_degC", "min_temp_degC", "tec_r298", "tec_beta",
+                      "calibration_date", "calibrated_by" ]:
+            self.pack_field(name)
                                     
         # ######################################################################
         # Page 2                    
         # ######################################################################
 
-        self.pack((2,  0, 16), "s", self.detector)
-        self.pack((2, 16,  2), "H", self.active_pixels_horizontal)
-        self.pack((2, 18,  1), "B", self.laser_warmup_sec)
-        self.pack((2, 19,  2), "H", self.active_pixels_vertical)
+        for name in [ "detector", "active_pixels_horizontal", "laser_warmup_sec",
+                      "active_pixels_vertical" ]:
+            self.pack_field(name)
+
         if self.format < 7:
-            self.pack((2, 21,  2), "H", max(0xffff, self.min_integration_time_ms))
-            self.pack((2, 23,  2), "H", max(0xffff, self.max_integration_time_ms))
+            self.pack_field("min_integration_time_ms")
+            self.pack_field("max_integration_time_ms")
         else:
             coeff = 0.0
             if len(wavelength_coeffs) > 4:
                 coeff = wavelength_coeffs[4]
             self.pack((2, 21,  4), "f", coeff)
-        self.pack((2, 25,  2), "H", self.actual_pixels_horizontal)
-        self.pack((2, 27,  2), "H", self.multi_wavelength_calibration.get("roi_horizontal_start"))
-        self.pack((2, 29,  2), "H", self.multi_wavelength_calibration.get("roi_horizontal_end"))
-        self.pack((2, 31,  2), "H", self.roi_vertical_region_1_start)
-        self.pack((2, 33,  2), "H", self.roi_vertical_region_1_end)
-        self.pack((2, 35,  2), "H", self.roi_vertical_region_2_start)
-        self.pack((2, 37,  2), "H", self.roi_vertical_region_2_end)
-        self.pack((2, 39,  2), "H", self.roi_vertical_region_3_start)
-        self.pack((2, 41,  2), "H", self.roi_vertical_region_3_end)
 
-        if False: # deprecated
-            if self.linearity_coeffs is not None: 
-                for i in range(min(5, len(self.linearity_coeffs))):
-                    self.pack((2, 43 + i * 4,  4), "f", self.linearity_coeffs[i])
-
+        for name in [ "actual_pixels_horizontal", 
+                      "roi_vertical_region_1_start", "roi_vertical_region_1_end",
+                      "roi_vertical_region_2_start", "roi_vertical_region_2_end",
+                      "roi_vertical_region_3_start", "roi_vertical_region_3_end" ]:
+            self.pack_field(name)
+            
         # ######################################################################
         # Page 3
         # ######################################################################
@@ -734,25 +736,28 @@ class EEPROM:
             for i in range(min(4, len(self.laser_power_coeffs))):
                 self.pack((3, 12 + i * 4,  4), "f", self.laser_power_coeffs[i])
 
-        self.pack((3, 28,  4), "f", self.max_laser_power_mW)
-        self.pack((3, 32,  4), "f", self.min_laser_power_mW)
+        for name in [ "max_laser_power_mW", "min_laser_power_mW",
+                      "min_integration_time_ms", "max_integration_time_ms",
+                      "laser_watchdog_sec", "light_source_type",
+                      "power_timeout_sec", "detector_timeout_sec", 
+                      "startup_scans_to_average", "laser_attenuator" ]:
+            self.pack_field(name)
+
         self.pack((3, 36,  4), "f", self.multi_wavelength_calibration.get("excitation_nm_float"))
-        self.pack((3, 40,  4), "I", self.min_integration_time_ms)
-        self.pack((3, 44,  4), "I", self.max_integration_time_ms)
         self.pack((3, 48,  4), "f", self.multi_wavelength_calibration.get("avg_resolution"))
-        self.pack((3, 52,  2), "H", self.laser_watchdog_sec)
-        self.pack((3, 54,  1), "B", self.light_source_type)
-        self.pack((3, 55,  2), "H", self.power_timeout_sec)
-        self.pack((3, 57,  2), "H", self.detector_timeout_sec)
         self.pack((3, 59,  1), "B", self.multi_wavelength_calibration.get("horiz_binning_mode"))
-        self.pack_field("startup_scans_to_average")
-        self.pack_field("laser_attenuator")
 
         # ######################################################################
         # Page 4
         # ######################################################################
 
-        self.pack((4,  0, 63), "s", self.user_text)
+        if self.user_text and self.user_data is None:
+            # regenerate user_data from user_text
+            self.user_data = [0] * self.PAGE_LENGTH
+            length = len(self.user_text)
+            for i in range(min(length, self.PAGE_LENGTH)):
+                self.user_data[i] = ord(self.user_text[i])
+        self.pack_field("user_data")
 
         # ######################################################################
         # Page 5
@@ -771,11 +776,14 @@ class EEPROM:
                 value = -1
             self.pack((5, i * 2, 2), "h", value)
 
-        self.pack((5, 30, 16), "s", self.product_configuration)
-        if self.assembly_revision:
-            self.assembly_revision_packed = self.assembly_revision.serialize()
+        for name in [ "product_configuration", "subformat" ]:
+            self.pack_field(name)
+
+        if self.format >= 18:
+            if self.assembly_revision:
+                self.assembly_revision_packed = self.assembly_revision.serialize()
             self.pack_field("assembly_revision_packed")
-        self.pack((5, 63,  1), "B", self.subformat)
+            # self.dump_write_buffers("after packing assembly_revision_packed")
 
         # ######################################################################
         # Page 6-7
@@ -804,6 +812,15 @@ class EEPROM:
         if self.model and "XS" in self.model.upper():
             # self.pack((8,  0, 16), "s", self.laser_password)
             self.pack_field("laser_password", quiet=True)
+
+            for name in [ "feature_mask_xs", "acc_state", 
+                          "acc_state_gpio1", "acc_state_gpio2", 
+                          "acc_cont_strobe_period_us", "acc_cont_strobe_width_us", 
+                          "acc_cont_strobe_delay_us", "acc_cont_strobe_count", 
+                          "max_battery_temp_deg_c", "pixel_calibration_type" ]:
+                self.pack_field(name)
+
+        self.dump_write_buffers("end of generate_write_buffers")
 
     # ##########################################################################
     #                                                                          #
@@ -932,7 +949,7 @@ class EEPROM:
         end_byte   = start_byte + length
 
         if page > len(self.write_buffers):
-            log.error("error unpacking EEPROM page %d, offset %d, len %d as %s: invalid page (label %s)", 
+            log.error("error packing EEPROM page %d, offset %d, len %d as %s: invalid page (label %s)", 
                 page, start_byte, length, data_type, label, exc_info=1)
             return
 
@@ -956,17 +973,14 @@ class EEPROM:
                     buf[start_byte + i] = 0
         elif data_type == "*":
             for i in range(start_byte, end_byte):
+                log.debug(f"pack: clearing buf {page}, byte {i}")
                 buf[i] = 0
             if isinstance(value, str):
-                value = value.removeprefix("0x")
-                new_value = []
-                for i in range(len(value) // 2):
-                    b = value[i*2:i*2+2]
-                    new_value.append(int(b, 16))
-                value = new_value
-            if isinstance(value, list):
-                for i in range(min(length, len(value))):
-                    buf[start_byte + i] = value[i]
+                value = utils.hex_string_to_data(value)
+                log.debug(f"pack: preparing to pack value {value}")
+            for i in range(min(length, len(value))):
+                offset = start_byte + i
+                buf[offset] = value[i]
         else:
             if data_type == "f":
                 value = float(value)
@@ -1032,6 +1046,11 @@ class EEPROM:
         self.multi_wavelength_calibration = tmp_mwc
 
         return s
+
+    def dump_write_buffers(self, label=None):
+        log.debug(f"EEPROM.write_buffers: {label}")
+        for i in range(len(self.write_buffers)):
+            log.debug(f"  page {i}: {utils.to_hex(self.write_buffers[i])}")
 
     ## log this object
     def dump(self):

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -1146,6 +1146,11 @@ class EEPROM:
         return EEPROM.LATEST_REV
 
     def get_horizontal_roi(self):
+        """
+        Note that on XS (see IMX385.py), our horizontal ROI for good signal 
+        should not extend outside (16, 1935). However, I'm not sure I want to
+        clamp that here. Leaving to WPSC to properly configure the EEPROM.
+        """
         start  = self.multi_wavelength_calibration.get("roi_horizontal_start", default=-1)
         end    = self.multi_wavelength_calibration.get("roi_horizontal_end", default=-1)
 

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -546,11 +546,14 @@ class EEPROM:
         # Page 8
         # ######################################################################
 
-        if "XS" in self.model.upper(): # and self.format >= 18:
-            
+        if "XS" in self.model.upper(): 
+
             s = self.unpack_field("laser_password", quiet=True)
-            if s is None or len(s) < 4 or any([c in [0x00, 0xff] for c in s]):
+            if s is None:
                 log.debug("no laser password found")
+                self.laser_password = None
+            elif len(s) < 4 or any([not (31 < ord(c) < 128) for c in s]):
+                log.debug("no valid laser password found")
                 self.laser_password = None
 
         # ######################################################################

--- a/wasatch/EEPROM.py
+++ b/wasatch/EEPROM.py
@@ -8,7 +8,8 @@ import re
 
 from . import utils
 
-from .ROI import ROI
+from .AssemblyRevision import AssemblyRevision
+from .ROI              import ROI
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ log = logging.getLogger(__name__)
 # @see 24LC128 for FX2 (16KB, https://www.microchip.com/en-us/product/24LC128)
 class EEPROM:
 
-    LATEST_REV = 18
+    LATEST_REV = 19
 
     MAX_PAGES = 9
     PAGE_LENGTH = 64
@@ -35,10 +36,12 @@ class EEPROM:
 
     DEFAULT_LASER_WATCHDOG_SEC = 10
 
+    # @see https://docs.python.org/2/library/struct.html#format-characters
+    # (capitals are unsigned)
     EEPROM_FIELDS = [
         ((0,  0, 16), "s", "model"),
         ((0, 16, 16), "s", "serial_number"),
-        ((0, 32,  4), "I", "baud_rate"),
+        ((0, 32,  4), "I", "baud_rate"), # deprecated
         ((0, 36,  1), "?", "has_cooling"),
         ((0, 37,  1), "?", "has_battery"),
         ((0, 38,  1), "?", "has_laser"),
@@ -83,12 +86,13 @@ class EEPROM:
         ((2, 37,  2), "H", "roi_vertical_region_2_end"),
         ((2, 39,  2), "H", "roi_vertical_region_3_start"),
         ((2, 41,  2), "H", "roi_vertical_region_3_end"),
-        ((2, 43,  4), "f", "linearity_c0"),
+        ((2, 43,  4), "f", "linearity_c0"), # deprecated...
         ((2, 47,  4), "f", "linearity_c1"),
         ((2, 51,  4), "f", "linearity_c2"),
         ((2, 55,  4), "f", "linearity_c3"),
         ((2, 59,  4), "f", "linearity_c4"),
 
+        ((3, 11,  1), "b", "max_laser_temp_deg_c"),
         ((3, 12,  4), "f", "laser_power_c0"),
         ((3, 16,  4), "f", "laser_power_c1"),
         ((3, 20,  4), "f", "laser_power_c2"),
@@ -109,6 +113,7 @@ class EEPROM:
         ((4,  0, 64), "s", "user_data"),
 
         ((5, 30, 16), "s", "product_configuration"),
+        ((5, 45,  6), "*", "assembly_revision_packed"),
         ((5, 63,  1), "B", "subformat"),
 
         ((8,  0, 15), "s", "laser_password"),
@@ -118,7 +123,7 @@ class EEPROM:
 
         self.model                       = None
         self.serial_number               = None
-        self.baud_rate                   = 0
+        self.baud_rate                   = 0 # deprecated
         self.has_cooling                 = False    # explicitly means detector TEC, not laser
         self.has_battery                 = False
         self.has_laser                   = False
@@ -182,8 +187,10 @@ class EEPROM:
         self.roi_vertical_region_2_end   = 0
         self.roi_vertical_region_3_start = 0
         self.roi_vertical_region_3_end   = 0
-        self.linearity_coeffs            = []
+        self.linearity_coeffs            = [] # deprecated
 
+
+        self.max_laser_temp_deg_c        = None
         self.max_laser_power_mW          = 0.0
         self.min_laser_power_mW          = 0.0
         self.laser_power_coeffs          = []
@@ -194,6 +201,8 @@ class EEPROM:
 
         self.bad_pixels                  = [] # should be set, not list (but this works with EEPROMEditor)
         self.product_configuration       = None
+        self.assembly_revision_packed    = None
+        self.assembly_revision           = None
 
         self.laser_password              = None
 
@@ -225,7 +234,7 @@ class EEPROM:
             "laser_power_coeffs",
             "laser_warmup_sec",
             "laser_watchdog_sec",
-            "linearity_coeffs",
+           #"linearity_coeffs", # deprecated
             "max_laser_power_mW",
             "min_laser_power_mW",
             "raman_intensity_coeffs",
@@ -337,7 +346,7 @@ class EEPROM:
 
         self.model                           = self.unpack((0,  0, 16), "s", "model")
         self.serial_number                   = self.unpack((0, 16, 16), "s", "serial")
-        self.baud_rate                       = self.unpack((0, 32,  4), "I", "baud")
+        self.baud_rate                       = 0 # self.unpack((0, 32,  4), "I", "baud") # deprecated
         self.has_cooling                     = self.unpack((0, 36,  1), "?", "cooling")
         self.has_battery                     = self.unpack((0, 37,  1), "?", "battery")
         self.has_laser                       = self.unpack((0, 38,  1), "?", "laser")
@@ -422,16 +431,20 @@ class EEPROM:
         self.roi_vertical_region_3_start     = self.unpack((2, 39,  2), "H" if self.format >= 4 else "h")
         self.roi_vertical_region_3_end       = self.unpack((2, 41,  2), "H" if self.format >= 4 else "h")
         self.linearity_coeffs = []
-        self.linearity_coeffs          .append(self.unpack((2, 43,  4), "f", "linearity_coeff_0")) # overloading for secondary ADC
-        self.linearity_coeffs          .append(self.unpack((2, 47,  4), "f"))
-        self.linearity_coeffs          .append(self.unpack((2, 51,  4), "f"))
-        self.linearity_coeffs          .append(self.unpack((2, 55,  4), "f"))
-        self.linearity_coeffs          .append(self.unpack((2, 59,  4), "f"))
+        if False: # deprecated
+            self.linearity_coeffs          .append(self.unpack((2, 43,  4), "f", "linearity_coeff_0")) # overloading for secondary ADC
+            self.linearity_coeffs          .append(self.unpack((2, 47,  4), "f"))
+            self.linearity_coeffs          .append(self.unpack((2, 51,  4), "f"))
+            self.linearity_coeffs          .append(self.unpack((2, 55,  4), "f"))
+            self.linearity_coeffs          .append(self.unpack((2, 59,  4), "f"))
 
         # ######################################################################
         # Page 3
         # ######################################################################
         
+        if self.format >= 18:
+            self.unpack_field("max_laser_temp_deg_c")
+
         self.laser_power_coeffs = []
         self.laser_power_coeffs        .append(self.unpack((3, 12,  4), "f", "laser_power_coeff_0"))
         self.laser_power_coeffs        .append(self.unpack((3, 16,  4), "f"))
@@ -486,6 +499,9 @@ class EEPROM:
 
         if self.format >= 5:
             self.product_configuration       = self.unpack((5,  30, 16), "s", "product_configuration")
+        if self.format >= 18:
+            self.unpack_field("assembly_revision_packed")
+            self.assembly_revision = AssemblyRevision(self.assembly_revision_packed)
         if self.format >= 7:
             self.subformat                   = self.unpack((5,  63,  1), "B", "subformat")
 
@@ -638,7 +654,7 @@ class EEPROM:
 
         self.pack((0,  0, 16), "s", self.model)
         self.pack((0, 16, 16), "s", self.serial_number)
-        self.pack((0, 32,  4), "I", self.baud_rate)
+        self.pack((0, 32,  4), "I", self.baud_rate) # deprecated (zero)
         self.pack((0, 36,  1), "?", self.has_cooling)
         self.pack((0, 37,  1), "?", self.has_battery)
         self.pack((0, 38,  1), "?", self.has_laser)
@@ -703,14 +719,16 @@ class EEPROM:
         self.pack((2, 39,  2), "H", self.roi_vertical_region_3_start)
         self.pack((2, 41,  2), "H", self.roi_vertical_region_3_end)
 
-        if self.linearity_coeffs is not None:
-            for i in range(min(5, len(self.linearity_coeffs))):
-                self.pack((2, 43 + i * 4,  4), "f", self.linearity_coeffs[i])
+        if False: # deprecated
+            if self.linearity_coeffs is not None: 
+                for i in range(min(5, len(self.linearity_coeffs))):
+                    self.pack((2, 43 + i * 4,  4), "f", self.linearity_coeffs[i])
 
         # ######################################################################
         # Page 3
         # ######################################################################
 
+        self.pack_field("max_laser_temp_deg_c")
         if self.laser_power_coeffs is not None:
             for i in range(min(4, len(self.laser_power_coeffs))):
                 self.pack((3, 12 + i * 4,  4), "f", self.laser_power_coeffs[i])
@@ -753,6 +771,9 @@ class EEPROM:
             self.pack((5, i * 2, 2), "h", value)
 
         self.pack((5, 30, 16), "s", self.product_configuration)
+        if self.assembly_revision:
+            self.assembly_revision_packed = self.assembly_revision.serialize()
+            self.pack_field("assembly_revision_packed")
         self.pack((5, 63,  1), "B", self.subformat)
 
         # ######################################################################
@@ -871,6 +892,9 @@ class EEPROM:
                 if c == 0:
                     break
                 unpack_result += chr(c)
+        elif data_type == "*":
+            # non-standard Wasatch extension
+            unpack_result = buf[start_byte:end_byte]
         else:
             unpack_result = 0
             try:
@@ -929,6 +953,13 @@ class EEPROM:
                     buf[start_byte + i] = ord(value[i])
                 else:
                     buf[start_byte + i] = 0
+        elif data_type == "*":
+            # non-standard extension
+            for i in range(start_byte, end_byte):
+                buf[i] = 0
+            if value is not None:
+                for i in range(min(length, len(value))):
+                    buf[i] = value[i]
         else:
             if data_type == "f":
                 value = float(value)
@@ -1000,7 +1031,7 @@ class EEPROM:
         log.debug("EEPROM settings:")
         log.debug("  Model:            %s", self.model)
         log.debug("  Serial Number:    %s", self.serial_number)
-        log.debug("  Baud Rate:        %d", self.baud_rate)
+       #log.debug("  Baud Rate:        %d", self.baud_rate) # deprecated
         log.debug("  Has Cooling:      %s", self.has_cooling)
         log.debug("  Has Battery:      %s", self.has_battery)
         log.debug("  Has Laser:        %s", self.has_laser)
@@ -1055,8 +1086,9 @@ class EEPROM:
         log.debug("  ROI Vert Reg 1:   (%d, %d)", self.roi_vertical_region_1_start, self.roi_vertical_region_1_end)
         log.debug("  ROI Vert Reg 2:   (%d, %d)", self.roi_vertical_region_2_start, self.roi_vertical_region_2_end)
         log.debug("  ROI Vert Reg 3:   (%d, %d)", self.roi_vertical_region_3_start, self.roi_vertical_region_3_end)
-        log.debug("  Linearity Coeffs: %s", self.linearity_coeffs)
+       #log.debug("  Linearity Coeffs: %s", self.linearity_coeffs) # deprecated
         log.debug("")
+        log.debug("  Max Laser Temp:   %d degC", self.max_laser_temp_deg_c)
         log.debug("  Laser coeffs:     %s", self.laser_power_coeffs)
         log.debug("  Max Laser Power:  %s mW", self.max_laser_power_mW)
         log.debug("  Min Laser Power:  %s mW", self.min_laser_power_mW)
@@ -1066,6 +1098,7 @@ class EEPROM:
         log.debug("")
         log.debug("  Bad Pixels:       %s", self.bad_pixels)
         log.debug("  Product Config:   %s", self.product_configuration)
+        log.debug("  Assembly Rev:     %s", self.assembly_revision)
 
         if self.subformat == 1:
             self.dump_raman_intensity_calibration()

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -13,23 +13,24 @@ from time   import sleep
 
 from . import utils
 
-from .SpectrometerSettings import SpectrometerSettings
-from .SpectrometerResponse import SpectrometerResponse, ErrorLevel
-from .SpectrometerRequest  import SpectrometerRequest
-from .SpectrometerState    import SpectrometerState
-from .InterfaceDevice      import InterfaceDevice
-from .DetectorRegions      import DetectorRegions
-from .ControlObject        import ControlObject
-from .StatusMessage        import StatusMessage
-from .RealUSBDevice        import RealUSBDevice
-from .MockUSBDevice        import MockUSBDevice
-from .AreaScanImage        import AreaScanImage
-from .DetectorROI          import DetectorROI
-from .PollStatus           import PollStatus
-from .Reading              import Reading
-from .EEPROM               import EEPROM
-from .IMX385               import IMX385
-from .ROI                  import ROI
+from .USBCPowerConnectionState import USBCPowerConnectionState
+from .SpectrometerSettings     import SpectrometerSettings
+from .SpectrometerResponse     import SpectrometerResponse, ErrorLevel
+from .SpectrometerRequest      import SpectrometerRequest
+from .SpectrometerState        import SpectrometerState
+from .InterfaceDevice          import InterfaceDevice
+from .DetectorRegions          import DetectorRegions
+from .ControlObject            import ControlObject
+from .StatusMessage            import StatusMessage
+from .RealUSBDevice            import RealUSBDevice
+from .MockUSBDevice            import MockUSBDevice
+from .AreaScanImage            import AreaScanImage
+from .DetectorROI              import DetectorROI
+from .PollStatus               import PollStatus
+from .Reading                  import Reading
+from .EEPROM                   import EEPROM
+from .IMX385                   import IMX385
+from .ROI                      import ROI
 
 log = logging.getLogger(__name__)
 
@@ -267,22 +268,11 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.get_fpga_firmware_version()
         log.debug(f"FPGA firmware version {self.settings.fpga_firmware_version}")
 
-        # self.get_microcontroller_serial_number()
-        # log.debug(f"Microcontroller serial number {self.settings.microcontroller_serial_number}")
+        self.get_microcontroller_serial_number()
+        log.debug(f"Microcontroller serial number {self.settings.microcontroller_serial_number}")
 
-        # issue: BL652 may not be fully booted if this was a hotplug. We could
-        #        of course re-poll if None, but the initial SpectrometerSettings
-        #        will already have been used to populate the EEPROMEditor. What
-        #        we really need to do is send a "change" in this setting upstream
-        #        via the MessageQueue, and have a listener in ENLIGHTEN/caller
-        #        for such updates. The way we mainly do this now is by adding
-        #        fields to Reading (like temperature, battery, laser interlock
-        #        etc), since most dynamic (uncommanded) changes in spectrometer 
-        #        state are usually measurement-related. It would be a little 
-        #        weird to add a "dynamic firmware version" to Reading, implying
-        #        that firmware versions might suddenly change mid-runtime...
-        # self.get_ble_firmware_version()
-        # log.debug(f"BLE firmware version {self.settings.ble_firmware_version}")
+        self.get_power_connection_state()
+        log.debug(f"Power connection state {self.settings.state.power_connection_state}")
 
         # ######################################################################
         # model-specific settings
@@ -461,6 +451,9 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.connecting = False
 
         self.settings.state.dump("FID.post_connect")
+
+        if self.settings.is_xs():
+            self.queue_message("marquee_info", "stabilizing sensor")
 
         return SpectrometerResponse(self.connected)
         
@@ -1225,8 +1218,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
         return SpectrometerResponse(data=s)
 
     def get_microcontroller_serial_number(self):
-        if not self.settings.is_arm():
-            log.debug("GET_MICROCONTROLLER_SERIAL_NUMBER requires ARM")
+        if not self.settings.is_xs():
+            log.debug("GET_MICROCONTROLLER_SERIAL_NUMBER requires XS")
             return None
 
         if not self.settings.supports_feature("microcontroller_serial_number"):
@@ -1250,19 +1243,19 @@ class FeatureIdentificationDevice(InterfaceDevice):
     def get_ble_firmware_version(self):
         if not self.settings.is_arm():
             log.debug("GET_BLE_FIRMWARE_VERSION requires ARM")
-            return None
+            return
 
         if not self.settings.supports_feature("get_ble_firmware_version"):
             log.debug("GET_BLE_FIRMWARE_VERSION not supported on this firmware")
-            return None
+            return
 
         result = self._get_code(0xff, wValue=0x2d, wLength=32, label="GET_BLE_FIRMWARE_VERSION")
         if result is None:
-            return None
+            return
 
         data = result.data
         if data is None:
-            return None
+            return
 
         s = ""
         for c in data:
@@ -1271,6 +1264,34 @@ class FeatureIdentificationDevice(InterfaceDevice):
             s += chr(c)
         self.settings.ble_firmware_version = s
         return SpectrometerResponse(data=s)
+
+    def get_power_connection_state(self):
+        if not self.settings.is_xs():
+            log.debug("GET_POWER_CONNECTION_STATE requires XS")
+            return
+
+        if not self.settings.supports_feature("get_power_connection_state"):
+            log.debug("GET_POWER_CONNECTION_STATE not supported on this firmware")
+            return
+
+        result = self._get_code(0xff, wValue=0x78, wLength=5, label="GET_POWER_CONNECTION_STATE")
+        if result is None:
+            return
+
+        data = result.data
+        if data is None:
+            return
+
+        if len(data) != 5:
+            log.error(f"get_power_connection_state: expected 5 bytes, received {len(data)}")
+            return
+
+        state = USBCPowerConnectionState(data)
+        self.settings.state.power_connection_state = state
+
+        log.debug(f"Power connection state: {state} ({state.long()})")
+
+        return SpectrometerResponse(data=state)
 
     def apply_edc(self, spectrum):
         """

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -110,7 +110,6 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.ccd_temperature_invalid = False
 
         self.settings = SpectrometerSettings(device_id)
-        self.eeprom_backup = None
 
         self.alerts = set()
 
@@ -3724,8 +3723,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
         """
         log.debug("fid.update_session_eeprom: %s updating EEPROM instance", self.settings.eeprom.serial_number)
 
-        if not self.eeprom_backup:
-            self.eeprom_backup = copy.deepcopy(self.settings.eeprom)
+        if not self.settings.eeprom_backup:
+            self.settings.eeprom_backup = copy.deepcopy(self.settings.eeprom)
 
         self.settings.eeprom.update_editable(pair[1])
         return SpectrometerResponse(data=True)
@@ -3737,8 +3736,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
         """
         log.debug("fid.replace_session_eeprom: %s replacing EEPROM instance", self.settings.eeprom.serial_number)
 
-        if not self.eeprom_backup:
-            self.eeprom_backup = copy.deepcopy(self.settings.eeprom)
+        if not self.settings.eeprom_backup:
+            self.settings.eeprom_backup = copy.deepcopy(self.settings.eeprom)
 
         self.settings.eeprom = pair[1]
         self.settings.eeprom.dump()
@@ -3746,15 +3745,15 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
     ## Actually store the current session EEPROM fields to the spectrometer.
     def write_eeprom(self):
-        if not self.eeprom_backup:
+        if not self.settings.eeprom_backup:
             log.critical("expected to update or replace EEPROM object before write command")
             self.queue_message("marquee_error", "Failed to write EEPROM")
             return SpectrometerResponse(data=False, error_msg="failed to write eeprom")
 
         # backup contents of previous EEPROM in log
         log.debug("Original EEPROM contents")
-        self.eeprom_backup.dump()
-        log.debug("Original EEPROM buffers: %s", self.eeprom_backup.buffers)
+        self.settings.eeprom_backup.dump()
+        log.debug("Original EEPROM buffers: %s", self.settings.eeprom_backup.buffers)
 
         try:
             self.settings.eeprom.generate_write_buffers()

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -2319,8 +2319,9 @@ class FeatureIdentificationDevice(InterfaceDevice):
         environmental conditions.
         """
         if not self.settings.eeprom.has_cooling:
-            log.error("unable to control TEC: EEPROM reports no cooling")
-            return SpectrometerResponse(data=False, error_lvl=ErrorLevel.low, error_msg="unable to control TEC: EEPROM reports no cooling")
+            msg = "unable to configure detector TEC: EEPROM reports no cooling"
+            log.error(msg)
+            return SpectrometerResponse(data=False, error_lvl=ErrorLevel.low, error_msg=msg)
 
         if degC < self.settings.eeprom.min_temp_degC:
             log.critical("set_detector_tec_setpoint_degC: setpoint %f below min %f", degC, self.settings.eeprom.min_temp_degC)
@@ -2355,12 +2356,14 @@ class FeatureIdentificationDevice(InterfaceDevice):
     ## @todo rename set_detector_tec_enable
     def set_tec_enable(self, flag: bool):
         if not self.settings.eeprom.has_cooling:
-            log.debug("unable to control TEC: EEPROM reports no cooling")
-            return SpectrometerResponse(data=False, error_msg="unable to control TEC: EEPROM reports no cooling")
+            msg = "unable to control detector TEC: EEPROM reports no cooling"
+            log.debug(msg)
+            return SpectrometerResponse(data=False, error_msg=msg)
 
         if not self.settings.eeprom.has_detector_tec_calibration():
-            log.debug("unable to control TEC: EEPROM missing valid TEC calibration")
-            return SpectrometerResponse(data=False, error_msg="unable to control TEC: EEPROM missing valid TEC calibration")
+            msg = "unable to control detector TEC: EEPROM missing valid TEC calibration"
+            log.debug(msg)
+            return SpectrometerResponse(data=False, error_msg=msg)
 
         value = 1 if flag else 0
 
@@ -3464,7 +3467,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
     def get_tec_enabled(self):
         if not self.settings.eeprom.has_cooling:
-            log.error("unable to control TEC: EEPROM reports no cooling")
+            log.error("unable to control detector TEC: EEPROM reports no cooling")
             return SpectrometerResponse(data=False, error_msg="no cooling reported")
         res = self._get_code(0xda, label="GET_CCD_TEC_ENABLED", msb_len=1)
         res.data = 0 != res.data

--- a/wasatch/FeatureIdentificationDevice.py
+++ b/wasatch/FeatureIdentificationDevice.py
@@ -85,16 +85,10 @@ class FeatureIdentificationDevice(InterfaceDevice):
     def __init__(self, device_id, message_queue=None, alert_queue=None):
         """
         Instantiate a FeatureIdentificationDevice with from the given device_id.
-        @param device_id [in] device ID ("USB:0x24aa:0x1000:1:24")
         @param message_queue [in] if provided, provides an outbound (from FID 
                to WrapperWorker) queue for writing StatusMessage objects upstream
-        @param alert_queue [in] if provided, accepts an inbound (from 
-               WrapperWorker to FID) queue for receiving AlertMessage objects 
         """
-        super().__init__()
-        self.device_id = device_id
-        self.message_queue = message_queue
-        self.alert_queue = alert_queue
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
         self.device = None
         if "MOCK" in str(device_id).upper():
@@ -111,8 +105,6 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.ccd_temperature_invalid = False
 
         self.settings = SpectrometerSettings(device_id)
-
-        self.alerts = set()
 
         # ######################################################################
         # these are "driver state" within FeatureIdentificationDevice, and don't
@@ -388,7 +380,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         log.debug("configuring FPGA")
 
         # automatically push EEPROM values to the FPGA (on modern EEPROMs)
-        # (this will work on Series-XS as well, even if we subsequently track its gain
+        # (this will work on XS as well, even if we subsequently track its gain
         #  somewhat differently as state.gain_db)
         if self.settings.eeprom.format >= 4:
             log.debug("sending gain/offset to FPGA")
@@ -1033,7 +1025,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         if update_session_eeprom:
             self.settings.eeprom.detector_gain = gain
 
-        if self.settings.is_micro():
+        if self.settings.is_xs():
             self.settings.state.gain_db = gain
 
         return SpectrometerResponse(data=gain)
@@ -1096,7 +1088,6 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.settings.eeprom.detector_gain = gain
 
         if self.settings.is_xs():
-            # self.queue_message("marquee_info", "sensor is stabilizing (gain)")
             self.settings.state.gain_db = gain
 
         return result
@@ -1333,13 +1324,12 @@ class FeatureIdentificationDevice(InterfaceDevice):
         return [ v - avg_dark for v in spectrum ]
 
     def get_line(self, trigger=True, auto_raman_params=None):
-        """ legacy alias """
         return self.get_spectrum(trigger, auto_raman_params)
 
     def generate_timeout_ms(self):
         max_integ_ms = max(self.settings.state.integration_time_ms, self.settings.state.prev_integration_time_ms)
         if self.settings.is_xs():
-            # we have no idea if Series-XS has to "wake up" the sensor, so wait
+            # we have no idea if XS has to "wake up" the sensor, so wait
             # long enough for 20ms + 8 throwaway frames if need be (IMX385 datasheet p69)
             if self.settings.state.onboard_averaging:
                 timeout_ms = max_integ_ms * (self.settings.state.scans_to_average + 7) + 500 * self.settings.num_connected_devices + 20
@@ -1362,6 +1352,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         @param trigger (Input) send an initial ACQUIRE
         @param auto_raman_params (Input) if present, use VR_ACQUIRE_AUTO_RAMAN 
                  rather than the usual VR_ACQUIRE_CCD
+
         @returns tuple of (spectrum[], area_scan_row_count) for success
         @returns None when it times-out while waiting for an external trigger
                  (interpret as, "didn't find any fish this time, try again in a bit")
@@ -1610,7 +1601,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         ########################################################################
 
         if not self.settings.state.area_scan_enabled:
-            if self.settings.is_micro() and utils.all_same(spectrum):
+            if self.settings.is_xs() and utils.all_same(spectrum):
                 response.error_msg = "skipping flat spectrum"
                 response.error_lvl = ErrorLevel.low
                 response.keep_alive = True
@@ -1729,10 +1720,6 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.require_throwaway(ms != self.settings.state.integration_time_ms)
         self.settings.state.prev_integration_time_ms = self.settings.state.integration_time_ms
         self.settings.state.integration_time_ms = ms
-
-        if self.settings.is_xs():
-            # self.queue_message("marquee_info", "sensor is stabilizing (int time)")
-            pass
 
         return result
 
@@ -1853,6 +1840,10 @@ class FeatureIdentificationDevice(InterfaceDevice):
     def get_area_scan_xs(self):
         """
         @returns Reading(spectrum, AreaScanImage(data=nd_array))
+        @see sensor docs in IMX385.py
+
+        Physically, the largest area scan image ENLIGHTEN or WPSC can generate is
+        (1952, 1097).
         """
         start = self.settings.eeprom.roi_vertical_region_1_start
         stop  = self.settings.eeprom.roi_vertical_region_1_end
@@ -2573,7 +2564,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         self.set_strobe_enable(flag)
 
         if self.settings.is_xs():
-            # Series-XS getLaserEnable doesn't provide immediate confirmation 
+            # XS getLaserEnable doesn't provide immediate confirmation 
             # because it's comingled with laserWatchdogSec and probably 
             # laserDelaySec
             return SpectrometerResponse(data=True)
@@ -2830,9 +2821,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
             return SpectrometerResponse(data=None, error_msg=msg)
 
         if not self.settings.supports_feature("get_laser_warning_delay_sec"):
-            msg = "GET_LASER_WARNING_DELAY_SEC not supported on this firmware"
-            log.error(msg)
-            return SpectrometerResponse(data=None, error_msg=msg)
+            log.error("GET_LASER_WARNING_DELAY_SEC not supported on this firmware, returning default 3")
+            return SpectrometerResponse(data=3)
 
         result = self._get_code(0x8b, lsb_len=1, label="GET_LASER_WARNING_DELAY_SEC")
         self.settings.state.laser_warning_delay_sec = result.data
@@ -2960,8 +2950,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
     ##
     # Enable "Raman mode" (automatic laser) in the spectrometer firmware.
     def set_raman_mode_enable_NOT_USED(self, flag: bool):
-        if not self.settings.is_micro():
-            log.debug("Raman mode only supported on Series-XS")
+        if not self.settings.is_xs():
+            log.debug("Raman mode only supported on XS")
             return SpectrometerResponse(data=False, error_msg="raman mode not supported")
 
         return self._send_code(bRequest        = 0xff,
@@ -2976,8 +2966,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
         return res
 
     def set_raman_delay_ms(self, ms: int):
-        if not self.settings.is_micro():
-            log.debug("Raman delay only supported on Series-XS")
+        if not self.settings.is_xs():
+            log.debug("Raman delay only supported on XS")
             return SpectrometerResponse(data=False, error_msg="raman delay not supported")
 
         # send value as big-endian
@@ -3001,11 +2991,11 @@ class FeatureIdentificationDevice(InterfaceDevice):
     #       logic itself is fixed), always send a DISABLE_LASER before changing the 
     #       watchdog period.
     def set_laser_watchdog_sec(self, sec):
-        if not self.settings.is_micro():
-            log.error("Laser watchdog only supported on Series-XS")
+        if not self.settings.is_xs():
+            log.error("Laser watchdog only supported on XS")
             return SpectrometerResponse(data=False, error_msg="laser watchdog not supported")
 
-        # remove this call after the Series-XS ARM / FPGA watchdog are fixed
+        # remove this call after the XS ARM / FPGA watchdog are fixed
         # MZ: are they fixed? can I remove this?
         # self.set_laser_enable(False)
 
@@ -3029,7 +3019,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
         @note we are not currently using this function
         """
-        if not self.settings.is_micro() or not self.settings.eeprom.has_laser:
+        if not self.settings.is_xs() or not self.settings.eeprom.has_laser:
             return SpectrometerResponse(data=False, error_msg="update laser watchdog not supported")
 
         int_ms = self.settings.state.integration_time_ms
@@ -3042,7 +3032,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         return self.set_laser_watchdog_sec(watchdog_sec)
 
     def update_vertical_roi(self):
-        if self.settings.is_micro():
+        if self.settings.is_xs():
             roi = self.settings.get_vertical_roi()
             if roi is not None:
                 self.set_vertical_roi(roi)
@@ -3054,7 +3044,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         if self.settings.fpga_firmware_version == "000-008" and self.settings.microcontroller_firmware_version == "0.1.0.7":
             return SpectrometerResponse(data=False)
 
-        if not self.settings.is_micro():
+        if not self.settings.is_xs():
             if not self.settings.supports_feature("hamamatsu_vertical_roi"):
                 log.warning("Vertical Binning only configurable on XS and prototype X/XM")
                 return SpectrometerResponse(data=False, error_msg="vertical binning not supported")
@@ -3080,6 +3070,10 @@ class FeatureIdentificationDevice(InterfaceDevice):
 
         if self.settings.is_xs():
             # ARM has USB opcodes for start/stop line
+
+            # Note that we should never have a start line less than 8, or stop 
+            # line above 1087 (see IMX385.py), but I'm not sure I want to clamp
+            # that here. Leaving that for WPSC to write to the EEPROM.
             self._send_code(bRequest=0xff, wValue=0x21, wIndex=start, label="SET_CMOS_START_LINE")
             self._send_code(bRequest=0xff, wValue=0x23, wIndex=end,   label="SET_CMOS_STOP_LINE")
         else:
@@ -3107,8 +3101,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
     # b11   12-bit     12-bit
     # \endverbatim
     def set_pixel_mode(self, mode: float):
-        if not self.settings.is_micro():
-            log.debug("Pixel Mode only configurable on Series-XS")
+        if not self.settings.is_xs():
+            log.debug("Pixel Mode only configurable on XS")
             return SpectrometerResponse(data=False, error_msg="pixel mode not supported")
 
         # we only care about the two least-significant bits
@@ -3172,8 +3166,8 @@ class FeatureIdentificationDevice(InterfaceDevice):
         
         @param args: either a DetectorROI or a tuple of (region, y0, y1, x0, x1)
         """
-        if not self.settings.is_micro():
-            log.debug("Detector ROI only configurable on Series-XS")
+        if not self.settings.is_xs():
+            log.debug("Detector ROI only configurable on XS")
             return SpectrometerResponse(data=False, error_msg="Detector ROI not configurable")
 
         if isinstance(args, DetectorROI):
@@ -3824,54 +3818,6 @@ class FeatureIdentificationDevice(InterfaceDevice):
         logging.getLogger().setLevel(lvl)
         return SpectrometerResponse()
 
-    def queue_message(self, setting, value):
-        """
-        If an upstream queue is defined, send the name-value pair.  Does nothing
-        if the caller hasn't provided a queue.
-
-        "setting" is application (caller) dependent, but ENLIGHTEN currently uses
-        "marquee_info" and "marquee_error".
-        """
-        if self.message_queue is None:
-            return SpectrometerResponse(data=False)
-
-        msg = StatusMessage(setting, value)
-        try:
-            self.message_queue.put(msg) 
-        except:
-            log.error("failed to enqueue StatusMessage (%s, %s)", setting, value, exc_info=1)
-            return SpectrometerResponse(data=False, error_msg="failed to enqueue messsage")
-        return SpectrometerResponse(data=True)
-
-    def check_alert(self, s):
-        log.debug(f"checking for alert {s}")
-        self.refresh_alerts()
-        if s in self.alerts:
-            log.debug(f"found {s} (clearing)")
-            self.alerts.remove(s)
-            return True
-
-    def refresh_alerts(self):
-        if self.alert_queue is None:
-            return
-
-        if self.alert_queue.empty():
-            return
-
-        while not self.alert_queue.empty():
-            alert = self.alert_queue.get_nowait()
-            if alert is None:
-                continue
-            elif isinstance(alert, ControlObject):
-                if alert.value:
-                    log.debug(f"raised alert {alert.setting}")
-                    self.alerts.add(alert.setting)
-                else:
-                    log.debug(f"cleared alert {alert.setting}")
-                    self.alerts.discard(alert.setting)
-            else:
-                log.error(f"non-ControlObject found in alerts_queue: {alert}")
-
     def _init_process_funcs(self):
         """
         Is it the expectation that all of these functions will return 
@@ -3978,6 +3924,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
                 "set_laser_power_require_modulation",
                 "set_laser_tec_mode",
                 "set_laser_temperature_setpoint_raw",
+                "set_laser_warning_delay_sec",
                 "set_laser_watchdog_sec",
                 "set_log_level",
                 "set_mod_delay_us",
@@ -4006,6 +3953,9 @@ class FeatureIdentificationDevice(InterfaceDevice):
         # Long term, the upstream requests should be changed to match the new format
         # This is an easy fix for the time being to make things behave
         ##################################################################
+
+        # MZ: deprecate these from ENLIGHTEN? Also used by AutoRaman
+
         # spectrometer control
         process_f["laser_enable"]                       = lambda x: self.set_laser_enable(bool(x))
         process_f["integration_time_ms"]                = lambda x: self.set_integration_time_ms(x)
@@ -4025,7 +3975,6 @@ class FeatureIdentificationDevice(InterfaceDevice):
         process_f["laser_power_high_resolution"]        = lambda x: self.set_laser_power_high_resolution(x)
         process_f["laser_power_require_modulation"]     = lambda x: self.set_laser_power_require_modulation(x)
         process_f["selected_laser"]                     = lambda x: self.set_selected_laser(int(x))
-        process_f["set_laser_warning_delay_sec"]        = lambda x: self.set_laser_warning_delay_sec(int(x))
 
         process_f["high_gain_mode_enable"]              = lambda x: self.set_high_gain_mode_enable(bool(x))
         process_f["trigger_source"]                     = lambda x: self.set_trigger_source(int(x))
@@ -4050,7 +3999,7 @@ class FeatureIdentificationDevice(InterfaceDevice):
         # BatchCollection
         process_f["take_one_request"]                   = lambda x: self.settings.state.set("take_one_request", x)
 
-        # Series-XS
+        # XS
        #f["raman_mode_enable"]                          = lambda x: self.set_raman_mode_enable(bool(x))
         process_f["raman_delay_ms"]                     = lambda x: self.set_raman_delay_ms(int(round(x)))
         process_f["laser_watchdog_sec"]                 = lambda x: self.set_laser_watchdog_sec(int(round(x)))

--- a/wasatch/FirmwareRequirements.py
+++ b/wasatch/FirmwareRequirements.py
@@ -17,10 +17,11 @@ class FirmwareRequirements:
 
         self.feature_versions = {
             "imx_stabilization":                { "microcontroller": { "min": "1.0.7.0" } },
-            "microcontroller_serial_number":    { "microcontroller": { "min": "1.0.4.5", "unsupported": [ "11.3.0.37" ] } },
-            "get_ble_firmware_version":         { "microcontroller": { "min": "1.0.4.5", "unsupported": [ "11.3.0.37", "1.0.33.7" ] } },
-            "get_laser_warning_delay_sec":      { "microcontroller": { "min": "1.0.4.5", "unsupported": [ "11.3.0.37" ] } },
-            "hamamatsu_vertical_roi":           { "microcontroller": { "min": "10.0.0.47" } }, # , "fpga": { "min": "35_12_0", "includes": "_" } },
+            "microcontroller_serial_number":    { "microcontroller": { "min": "1.0.4.5",  "unsupported": [ "11.3.0.37" ] } },
+            "get_ble_firmware_version":         { "microcontroller": { "min": "1.0.4.5",  "unsupported": [ "11.3.0.37", "1.0.33.7" ] } },
+            "get_laser_warning_delay_sec":      { "microcontroller": { "min": "1.0.4.5",  "unsupported": [ "11.3.0.37" ] } },
+            "get_power_connection_state":       { "microcontroller": { "min": "1.0.63.5", "unsupported": [ "11.3.0.37" ] } },
+            "hamamatsu_vertical_roi":           { "microcontroller": { "min": "10.0.0.47" } }, 
             "xs_area_scan_offset_kludge":       { "fpga": { "min": "01_04_01", "max": "01_04_30", "includes": "_" } },
         }
 

--- a/wasatch/FirmwareRequirements.py
+++ b/wasatch/FirmwareRequirements.py
@@ -19,7 +19,7 @@ class FirmwareRequirements:
             "imx_stabilization":                { "microcontroller": { "min": "1.0.7.0" } },
             "microcontroller_serial_number":    { "microcontroller": { "min": "1.0.4.5",  "unsupported": [ "11.3.0.37" ] } },
             "get_ble_firmware_version":         { "microcontroller": { "min": "1.0.4.5",  "unsupported": [ "11.3.0.37", "1.0.33.7" ] } },
-            "get_laser_warning_delay_sec":      { "microcontroller": { "min": "1.0.4.5",  "unsupported": [ "11.3.0.37" ] } },
+            "get_laser_warning_delay_sec":      { "microcontroller": { "min": "1.0.27.1", "unsupported": [ "11.3.0.37" ] } },
             "get_power_connection_state":       { "microcontroller": { "min": "1.0.63.5", "unsupported": [ "11.3.0.37" ] } },
             "hamamatsu_vertical_roi":           { "microcontroller": { "min": "10.0.0.47" } }, 
             "xs_area_scan_offset_kludge":       { "fpga": { "min": "01_04_01", "max": "01_04_30", "includes": "_" } },

--- a/wasatch/IDSCamera.py
+++ b/wasatch/IDSCamera.py
@@ -477,6 +477,8 @@ class IDSCamera:
     def set_integration_time_ms(self, ms):
         # manually clamp to apparent "multi-UserSet" range of (15ms, 120sec)
         # deliberately round to ms resolution to simplify barrier comparisons
+        if ms is None:
+            ms = 15
         ms = int(round(min(120_000, max(ms, 15)), 0))
 
         us = ms * 1000.0

--- a/wasatch/IDSDevice.py
+++ b/wasatch/IDSDevice.py
@@ -7,6 +7,7 @@ from .SpectrometerResponse  import SpectrometerResponse, ErrorLevel
 from .SpectrometerSettings  import SpectrometerSettings
 from .InterfaceDevice       import InterfaceDevice
 from .IDSCamera             import IDSCamera
+from .AutoRaman             import AutoRaman
 from .DeviceID              import DeviceID
 from .Reading               import Reading
 from .IMX385                import IMX385
@@ -25,20 +26,45 @@ class IDSDevice(InterfaceDevice):
     # lifecycle
     ############################################################################
 
+    # MZ: who passes-in config_dir, scratch_dir and consumer_deletes_area_scan_image?
     def __init__(self, device_id, message_queue=None, alert_queue=None, config_dir=None, scratch_dir=None, consumer_deletes_area_scan_image=False):
-        super().__init__()
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
-        self.device_id = device_id
         self.process_f = self.init_process_funcs()
-        self.device = None
         self.camera = IDSCamera(scratch_dir=scratch_dir, consumer_deletes_area_scan_image=consumer_deletes_area_scan_image)
-
         self.imx385 = IMX385() # re-using existing binning
 
         self.session_reading_count = 0
         self.reset_averaging()
 
         self.config_dir = config_dir if config_dir else os.path.join(utils.get_default_data_dir(), "config")
+
+        # populate on connection
+        self.auto_raman = None 
+
+        # This may be set post-connection to connect this IDSDevice with a 
+        # WasatchDevice (with coupled FeatureInterfaceDevice) serving as a 
+        # laser driver board. 
+        #
+        # We also want to use its EEPROM, which means this really needs to be 
+        # populated BEFORE connection (so the JSON file, if found, will override
+        # EEPROM defaults).
+        #
+        # Thinking...
+        #
+        # 1. Assume ENLIGHTEN will have already enumerated / connected 220250
+        #    BEFORE IDSDevice, which will continue to require a plugin "click"
+        #    to connect for the foreseeable future.
+        # 2. Going forward, we could presumably write the IDS camera serial 
+        #    number to the 220250's EEPROM (perhaps in user_text) to "forcibly
+        #    associate" them and avoid mistakes. But we can't easily do that
+        #    to units already in the field.
+        # 3. Plan: give WasatchDeviceWrapper a lightweight "Multispec"-like
+        #    static registry of all connected WrapperWorkers, such that one
+        #    can iterate through and select a peer from the catalog.
+        # 4. Note that this whole discussion could potentially make the current
+        #    LaserControlFeature.current_spectrometer_callback unnecessary.
+        self.laser_device = None
 
     def connect(self):
         """
@@ -54,40 +80,55 @@ class IDSDevice(InterfaceDevice):
         log.debug(f"connect: trying to start {self.device_id}")
         self.camera.start()
 
-        # initialize default settings
-        self.settings = SpectrometerSettings(self.device_id)
-        self.settings.eeprom.excitation_nm_float = 785 
-        self.settings.eeprom.wavecal_coeffs = [0, 1, 0, 0, 0]
-        self.settings.eeprom.min_integration_time_ms = 15       # Default UserSet
-        self.settings.eeprom.max_integration_time_ms = 120_000  # LongExposure UserSet
+        # attempt to link to an existing InterfaceDevice (presumably a 
+        # WasatchDevice) with a laser but no detector
+        log.debug("connect: searching for available laser partner")
+        for interface_device in WasatchDeviceWrapper.get_interface_devices():
+            if not interface_device.settings.eeprom.detector or "none" in interface_device.settings.eeprom.detector.lower():
+                if interface_device.settings.eeprom.has_laser:
+                    log.debug(f"connect: linked to laser-only InterfaceDevice {interface_device.device_id}")
+                    self.laser_device = interface_device
 
-        # stomp from camera
-        self.settings.eeprom.model = self.camera.model_name
-        self.settings.eeprom.detector = self.camera.sensor_name
-        self.settings.eeprom.serial_number = self.camera.serial_number
-        self.settings.eeprom.detector_serial_number = self.camera.serial_number
-        self.settings.eeprom.active_pixels_horizontal = self.camera.width
-        self.settings.eeprom.active_pixels_vertical = self.camera.height
-        self.settings.eeprom.roi_vertical_region_1_start = 0
-        self.settings.eeprom.roi_vertical_region_1_end = self.camera.height
-        self.settings.eeprom.invert_x_axis = True
+        if self.laser_device:
+            log.debug("using laser_device EEPROM")
+        else:
+            # initialize default settings
+            self.settings = SpectrometerSettings(self.device_id)
+            self.settings.eeprom.excitation_nm_float = 785 
+            self.settings.eeprom.wavecal_coeffs = [0, 1, 0, 0, 0]
+            self.settings.eeprom.min_integration_time_ms = 15       # Default UserSet
+            self.settings.eeprom.max_integration_time_ms = 120_000  # LongExposure UserSet
 
-        # stomp from virtual eeprom
-        self.init_from_json()
-        self.settings.eeprom.multi_wavelength_calibration.initialize()
+            # stomp from camera
+            self.settings.eeprom.model = self.camera.model_name
+            self.settings.eeprom.detector = self.camera.sensor_name
+            self.settings.eeprom.serial_number = self.camera.serial_number
+            self.settings.eeprom.detector_serial_number = self.camera.serial_number
+            self.settings.eeprom.active_pixels_horizontal = self.camera.width
+            self.settings.eeprom.active_pixels_vertical = self.camera.height
+            self.settings.eeprom.roi_vertical_region_1_start = 0
+            self.settings.eeprom.roi_vertical_region_1_end = self.camera.height
+            self.settings.eeprom.invert_x_axis = True
 
-        # now that we've got our "final settings," compute derived values
-        self.settings.update_wavecal()
+            # stomp from virtual eeprom
+            self.init_from_json()
+            self.settings.eeprom.multi_wavelength_calibration.initialize()
+
+            # now that we've got our "final settings," compute derived values
+            self.settings.update_wavecal()
 
         # pass vertical ROI down into Camera (where binning occurs)
         self.set_start_line(self.settings.eeprom.roi_vertical_region_1_start)
         self.set_stop_line (self.settings.eeprom.roi_vertical_region_1_end)
         # no need to pass horizontal ROI, because that's handled in ENLIGHTEN
 
-        self.set_integration_time_ms(15)
+        self.set_integration_time_ms(self.settings.eeprom.startup_integration_time_ms)
+        self.set_gain_db(self.settings.eeprom.startup_gain_db)
 
         # since area scan is so important to this camera, perform full rotation
         self.camera.set_rotate_180(self.settings.eeprom.invert_x_axis)
+
+        self.auto_raman = AutoRaman(idevice=self, auto_collection_mode=True)
 
         log.debug("connect: success")
         return SpectrometerResponse(True)
@@ -100,6 +141,10 @@ class IDSDevice(InterfaceDevice):
 
     def init_from_json(self):
         """
+        This should be needed "less" now that we're associating IDS cameras with
+        EEPROM-equipped Wasatch "laser drivers", but retained for non-Raman support.
+
+        Example: IDS-4108809482-WP-02288.json
         {
           "detector_serial_number": "4108809482",
           "excitation_nm_float": 785.0,
@@ -112,7 +157,7 @@ class IDSDevice(InterfaceDevice):
                 5.00E-11
           ],
           "wp_model": "WP-785XS-FS-OEM+STARVIS",
-          "wp_serial_number": "WP-002288"
+          "wp_serial_number": "WP-02288"
         }
 
         """
@@ -139,19 +184,11 @@ class IDSDevice(InterfaceDevice):
                 log.debug(f"stomping eeprom.{attr} = {value}")
                 setattr(self.settings.eeprom, attr, value)
 
-        for k in [ "detector_gain",
-                   "excitation_nm_float", 
-                   "invert_x_axis", 
-                   "horiz_binning_enabled",       
-                   "horiz_binning_mode",
-                   "startup_integration_time_ms",
-                   "wavelength_coeffs",
-                   "roi_horizontal_end",
-                   "roi_horizontal_start",
-                   "roi_vertical_region_1_start",
-                   "roi_vertical_region_1_end",
-                   "avg_resolution" ]:
+        # copy over all fields matching standard wasatch.EEPROM attribute names
+        for k in self.settings.eeprom.fields:
             stomp(k)
+
+        # overrides where JSON has different name than EEPROM field
         for k, attr in [ [ "wp_model",         "model" ],
                          [ "wp_serial_number", "serial_number" ] ]:
             stomp(k, attr)
@@ -161,29 +198,44 @@ class IDSDevice(InterfaceDevice):
         It did not look like we need to stop/start the camera when changing exposure time:
         cpp/afl_features_live_qtwidgets/backend.cpp BackEnd::SetExposure
         """
+        if ms is None:
+            ms = 0
+        ms = max(ms, 15) # lowest supported by camera
         log.debug(f"set_integration_time_ms: {ms}ms")
         self.settings.state.integration_time_ms = self.camera.set_integration_time_ms(ms)
         return SpectrometerResponse(True)
 
-    def set_gain_factor(self, factor):
-        """ Appears to be a scalar multiplier rather than dB, since it defaults to 1.0? """
-        log.debug(f"set_gain_factor: gain factor {factor:.1f}")
+    def _set_gain_factor(self, factor):
+        """ 
+        Used by set_gain_db().
+        Appears to be a scalar multiplier rather than dB, since it defaults to 1.0? 
+        """
+        log.debug(f"_set_gain_factor: gain factor {factor:.1f}")
         self.settings.state.detector_gain = self.camera.set_gain_factor(factor)
         return SpectrometerResponse(True)
 
+    def set_detector_gain(self, db):
+        return self.set_gain_db(db)
+
     def set_gain_db(self, db):
+        if db is None:
+            return
         log.debug(f"set_gain_db: gain {db:.1f}")
         self.settings.state.gain_db = db
         factor = utils.from_db_to_linear(db)
-        return self.set_gain_factor(factor)
+        return self._set_gain_factor(factor)
 
     def set_start_line(self, line):
+        if line is None:
+            return
         log.debug(f"set_start_line: line {line}")
         self.camera.set_start_line(line)
         self.settings.eeprom.roi_vertical_region_1_start = line
         return SpectrometerResponse(True)
 
     def set_stop_line(self, line):
+        if line is None:
+            return
         log.debug(f"set_stop_line: line {line}")
         self.camera.set_stop_line(line)
         self.settings.eeprom.roi_vertical_region_1_end = line
@@ -224,11 +276,8 @@ class IDSDevice(InterfaceDevice):
 
     def get_spectrum(self):
         try:
-            # log.debug("get_spectrum: calling send_trigger")
             self.camera.send_trigger()
-            # log.debug("get_spectrum: back from send_trigger, calling camera.get_spectrum")
             spectrum = self.camera.get_spectrum()
-            # log.debug("get_spectrum: back from camera.get_spectrum")
         except:
             log.error("error getting spectrum from IDSCamera", exc_info=1)
             return SpectrometerResponse(False)
@@ -237,9 +286,7 @@ class IDSDevice(InterfaceDevice):
             log.debug("get_spectrum: received None")
             return SpectrometerResponse(False)
 
-        # log.debug("get_spectrum: applying horizontal binning")
         spectrum = self.apply_horizontal_binning(spectrum)
-        # log.debug("get_spectrum: done")
         return spectrum
 
     def apply_horizontal_binning(self, spectrum):
@@ -322,8 +369,44 @@ class IDSDevice(InterfaceDevice):
         # log.debug(f"acquire_data: returning {reading}")
         return SpectrometerResponse(data=reading)
 
-    def heartbeat(self, arg):
-        return SpectrometerResponse(data=True)
+    ############################################################################
+    # laser proxy (if coupled with 220250 "laser driver board"
+    ############################################################################
+
+    def can_laser_fire(self):
+        if not self.laser_device:
+            return SpectrometerResponse(False)
+        return self.laser_device.handle_requests([SpectrometerRequest("can_laser_fire")])[0]
+
+    def is_laser_firing(self):
+        if not self.laser_device:
+            return SpectrometerResponse(False)
+        return self.laser_device.handle_requests([SpectrometerRequest("is_laser_firing")])[0]
+
+    def set_laser_enable(self, flag):
+        if not self.laser_device:
+            return SpectrometerResponse(False)
+        return self.laser_device.handle_requests([SpectrometerRequest('set_laser_enable', args=[flag])])[0]
+
+    def get_laser_tec_mode(self):
+        if not self.laser_device:
+            return SpectrometerResponse(None)
+        return self.laser_device.handle_requests([SpectrometerRequest("get_laser_tec_mode")])[0]
+
+    def get_laser_warning_delay_sec(self):
+        if not self.laser_device:
+            return SpectrometerResponse(3)
+        return self.laser_device.handle_requests([SpectrometerRequest("get_laser_warning_delay_sec")])[0]
+
+    def set_laser_warning_delay_sec(self, sec):
+        if not self.laser_device:
+            return SpectrometerResponse(False)
+        return self.laser_device.handle_requests([SpectrometerRequest('set_laser_warning_delay_sec', args=[sec])])[0]
+
+    def get_ambient_temperature_degC(self):
+        if not self.laser_device:
+            return SpectrometerResponse(None)
+        return self.laser_device.handle_requests([SpectrometerRequest("get_ambient_temperature_degC")])[0]
 
     ############################################################################
     # utility
@@ -335,14 +418,26 @@ class IDSDevice(InterfaceDevice):
     def init_process_funcs(self):
         process_f = {}
 
+        for fn_name in [ 
+                "can_laser_fire",
+                "get_ambient_temperature_degC",
+                "get_laser_tec_mode",
+                "get_laser_warning_delay_sec",
+                "is_laser_firing",
+                "set_detector_gain",
+                "set_integration_time_ms",
+                "set_laser_enable",
+                "set_laser_warning_delay_sec",
+            ]:
+            process_f[fn_name] = getattr(self, fn_name)
+
         process_f["connect"]             = self.connect
         process_f["disconnect"]          = self.disconnect
         process_f["close"]               = self.disconnect
 
         process_f["acquire_data"]        = self.acquire_data
-        process_f["heartbeat"]           = self.heartbeat
+        process_f["get_line"]            = self.get_spectrum
                                          
-        # deliberately don't support gain_factor or detector_gain
         process_f["gain_db"]             = lambda x: self.set_gain_db(float(x)) 
         process_f["integration_time_ms"] = lambda x: self.set_integration_time_ms(int(x))
         process_f["scans_to_average"]    = lambda x: self.set_scans_to_average(int(x))

--- a/wasatch/IMX385.py
+++ b/wasatch/IMX385.py
@@ -5,6 +5,33 @@ log = logging.getLogger(__name__)
 
 class IMX385:
     """
+    @par ROI and Area Scan
+
+    The max vertical ROI we can set is 1097 pixels tall (0, 1096), and 
+    includes both the 1920x1080 "recording area" and the "effective margin 
+    for color processing."
+
+    We should never have a start line less than 8, or stop line above 1087,
+    as the sensor barely receives light there.
+
+    The horizontal region returned includes all 1952 physical columns:
+
+           4 ignored optical black
+           4 ignored area of effective pixel side
+           8 effective margin of color processing
+        1920 recording area
+           9 effective margin of color processing
+           4 ignored area of effective pixel side
+           3 horizontal dummy
+        ---- ------------------------------------
+        1952 total
+
+    Therefore, our default horizontal ROI for good signal should start at 
+    (16, 1935).
+
+    Physically, the largest area scan image ENLIGHTEN or WPSC can generate is
+    (1952, 1097).
+
     Long-term, it might be worth having separate classes for HorizontalBinning 
     and IMX385, which would allow characteristics for other sensors to go into 
     other classes. That would suggest having different EEPROM fields for color-

--- a/wasatch/InterfaceDevice.py
+++ b/wasatch/InterfaceDevice.py
@@ -1,23 +1,39 @@
 import logging
 
-from .SpectrometerResponse import SpectrometerResponse
-from .SpectrometerResponse import ErrorLevel
+from .SpectrometerResponse import SpectrometerResponse, ErrorLevel
+from .StatusMessage            import StatusMessage
 
 log = logging.getLogger(__name__)
 
 class InterfaceDevice:
-    def __init__(self):
+
+    def __init__(self, device_id, message_queue=None, alert_queue=None):
         """
         Any class that communicates to a spectrometer should inherit this class.
         It provides the common functions that avoid repeated code.
+
+        @param device_id     either DeviceID or string equiv ("USB:0x24aa:0x1000:1:24")
+        @param message_queue if provided, used to send status back to caller
+        @param alert_queue   if provided, used to receive hints and realtime 
+                             interrupts from caller, including cancellation of 
+                             long-running tasks like AutoRaman
 
         @todo move scan averaging, TakeOneRequest logic upstream from 
               WasatchDevice, AndorDevice etc to here (simplify children of this 
               class while while increasing code-reuse and consistency across all
               InterfaceDevice variants)
         """
+        self.device_id      = device_id
+        self.message_queue  = message_queue # outgoing status back to ENLIGHTEN 
+        self.alert_queue    = alert_queue   # incoming alerts from ENLIGHTEN 
+
+        # if passed a string representation of a DeviceID, deserialize it
+        if type(device_id) is str:
+            device_id = DeviceID(label=device_id)
+
         self.process_f = {}
         self.remaining_throwaways = 0
+        self.alerts = set()
 
     def handle_requests(self, requests):
         responses = []
@@ -38,6 +54,54 @@ class InterfaceDevice:
                 log.error(f"error in handling request {request} of {e}", exc_info=1)
                 responses.append(SpectrometerResponse(error_msg="error processing cmd", error_lvl=ErrorLevel.medium))
         return responses
+
+    def queue_message(self, setting, value):
+        """
+        If an upstream queue is defined, send the name-value pair.  Does nothing
+        if the caller hasn't provided a queue.
+
+        "setting" is application (caller) dependent, but ENLIGHTEN currently uses
+        "marquee_info" and "marquee_error".
+        """
+        if self.message_queue is None:
+            return SpectrometerResponse(data=False)
+
+        msg = StatusMessage(setting, value)
+        try:
+            self.message_queue.put(msg) 
+        except:
+            log.error("failed to enqueue StatusMessage (%s, %s)", setting, value, exc_info=1)
+            return SpectrometerResponse(data=False, error_msg="failed to enqueue messsage")
+        return SpectrometerResponse(data=True)
+
+    def refresh_alerts(self):
+        if self.alert_queue is None:
+            return
+
+        if self.alert_queue.empty():
+            return
+
+        while not self.alert_queue.empty():
+            alert = self.alert_queue.get_nowait()
+            if alert is None:
+                continue
+            elif isinstance(alert, ControlObject):
+                if alert.value:
+                    log.debug(f"raised alert {alert.setting}")
+                    self.alerts.add(alert.setting)
+                else:
+                    log.debug(f"cleared alert {alert.setting}")
+                    self.alerts.discard(alert.setting)
+            else:
+                log.error(f"non-ControlObject found in alerts_queue: {alert}")
+
+    def check_alert(self, s):
+        log.debug(f"checking for alert {s}")
+        self.refresh_alerts()
+        if s in self.alerts:
+            log.debug(f"found {s} (clearing)")
+            self.alerts.remove(s)
+            return True
 
 class InterfaceDeviceClassUnavailable(Exception):
     """

--- a/wasatch/MockUSBDevice.py
+++ b/wasatch/MockUSBDevice.py
@@ -15,6 +15,9 @@ from wasatch.EEPROM import EEPROM
 log = logging.getLogger(__name__)
 
 class MockUSBDevice(AbstractUSBDevice):
+    """
+    Note that this is NOT an InterfaceDevice.
+    """
 
     def __init__(self, spec_name, eeprom_name, eeprom_overrides=None, spectra_option=None):
         self.spec_name = spec_name

--- a/wasatch/OceanDevice.py
+++ b/wasatch/OceanDevice.py
@@ -42,24 +42,9 @@ class OceanDevice(InterfaceDevice):
     """
 
     def __init__(self, device_id, message_queue=None, alert_queue=None):
-        super().__init__()
-        # if passed a string representation of a DeviceID, deserialize it
-        if type(device_id) is str:
-            device_id = DeviceID(label=device_id)
-
-        self.device_id      = device_id
-        self.message_queue  = message_queue
-        self.alert_queue    = alert_queue
-
-        #self.lock = threading.Lock()
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
         self.connected = False
-
-        # Receives ENLIGHTEN's 'change settings' commands in the spectrometer
-        # process. Although a logical queue, has nothing to do with multiprocessing.
-        self.command_queue = []
-
-        self.immediate_mode = False
 
         self.settings = SpectrometerSettings(self.device_id)
         self.summed_spectra         = None
@@ -67,10 +52,6 @@ class OceanDevice(InterfaceDevice):
         self.session_reading_count  = 0
         self.take_one               = False
         self.failure_count          = 0
-
-        self.process_id = os.getpid()
-        self.last_memory_check = datetime.datetime.now()
-        self.last_battery_percentage = 0
 
         self.process_f = self._init_process_funcs()
 

--- a/wasatch/ProcessedReading.py
+++ b/wasatch/ProcessedReading.py
@@ -55,7 +55,10 @@ class ProcessedReading:
         self.recordable_reference = None
         self.recordable_dark = None
 
-        self.declared_match = None
+        self.library_matching_compound = None 
+        self.library_matching_score = None # may be (0, 1) or (0, 100) depending on plugin / algorithm
+        self.library_matching_engine = None # KIA, Pearson etc
+
         self.first_pixel = -1 # only used in .cropped (set by enlighten.HorizROI.process)
         self.plugin_metadata = None
 

--- a/wasatch/RealUSBDevice.py
+++ b/wasatch/RealUSBDevice.py
@@ -6,6 +6,11 @@ from .AbstractUSBDevice import AbstractUSBDevice
 log = logging.getLogger(__name__)
 
 class RealUSBDevice(AbstractUSBDevice):
+    """
+    Note that this is NOT an InterfaceDevice.
+
+    FeatureIdentificationDevice has one of these (or a MockUSBDevice, in virtual testing).
+    """
 
     def __init__(self,device_id):
         self.device_id = device_id

--- a/wasatch/SPIDevice.py
+++ b/wasatch/SPIDevice.py
@@ -87,7 +87,7 @@ class SPIDevice(InterfaceDevice):
     lock = threading.Lock()
 
     def __init__(self, device_id, message_queue=None, alert_queue=None):
-        super().__init__()
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
         ########################################################################
         # Attempt to import dependencies (connects to FT232H)
@@ -122,23 +122,9 @@ class SPIDevice(InterfaceDevice):
         # Proceed with initialization
         ########################################################################
 
-        # if passed a string representation of a DeviceID, deserialize it
-        if type(device_id) is str:
-            device_id = DeviceID(label=device_id)
-
-        self.device_id      = device_id
-        self.message_queue  = message_queue
-        self.alert_queue    = alert_queue
-
         self.connected = False
         self.disconnect = False
         self.acquiring = False
-
-        # Receives ENLIGHTEN's 'change settings' commands in the spectrometer
-        # process. Although a logical queue, has nothing to do with multiprocessing.
-        self.command_queue = []
-
-        self.immediate_mode = False
 
         self.settings = SpectrometerSettings(self.device_id)
         self.summed_spectra         = None
@@ -147,9 +133,6 @@ class SPIDevice(InterfaceDevice):
         self.take_one               = False
         self.failure_count          = 0
 
-        self.process_id = os.getpid()
-        self.last_memory_check = datetime.datetime.now()
-        self.last_battery_percentage = 0
         self.lambdas = None
         self.spec_index = 0
         self._scan_averaging = 1

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -391,9 +391,10 @@ class SpectrometerSettings:
 
     def is_xs(self):
         return (self.is_imx() 
-                or "micro" in self.full_model().lower()
-                or "sig"   in self.full_model().lower()
-                or "xs"    in self.full_model().lower()
+                or "micro"  in self.full_model().lower()
+                or "sig"    in self.full_model().lower()
+                or "xs"     in self.full_model().lower()
+                or '0x4000' in str(self.device_id)
                 or self.is_spi())
 
     def supports_feature(self, feature):

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -74,6 +74,8 @@ class SpectrometerSettings:
         self.update_wavecal()
         self.update_raman_intensity_factors()
 
+        self.eeprom_backup = None # used by both FID and enlighten.Spectrometer
+
         # ENLIGHTEN sends this so individual driver processes can adaptively scale USB timeouts
         self.num_connected_devices = 1
 

--- a/wasatch/SpectrometerSettings.py
+++ b/wasatch/SpectrometerSettings.py
@@ -68,6 +68,8 @@ class SpectrometerSettings:
         self.wavenumbers = None
         self.raman_intensity_factors = None
         self.linear_pixel_calibration = None
+        self.ingaas_correction = None
+        self.etalon_correction = None
 
         self.lock_wavecal = False
 

--- a/wasatch/SpectrometerState.py
+++ b/wasatch/SpectrometerState.py
@@ -99,7 +99,6 @@ class SpectrometerState:
         self.mod_enabled = False
         self.mod_period_us = 0 
         self.mod_width_us = 0
-        self.laser_pwm_perc = None # range (0, 100)
 
         # (gen 2.0 stuff, not yet used)
         self.analog_out_enabled = False

--- a/wasatch/SpectrometerState.py
+++ b/wasatch/SpectrometerState.py
@@ -92,8 +92,17 @@ class SpectrometerState:
 
         self.fan_enabled = False
         self.lamp_enabled = False
-        self.shutter_enabled = False
        #self.strobe_enabled = False  # this is not a thing -- the proper field is self.laser_enabled
+
+        # MZ: rename to "_open" or "_closed"
+        # ...or is this "shutter CONTROL is enabled?"
+        #
+        # Per AndorDevice.acquire_data where TakeOneRequest.take_dark is True,
+        # shutter_enabled == True appears to be "SHUTTER CLOSED"
+        #
+        # HOWEVER, per AndorDevice.set_shutter_enable, shutter_enabled == True appears to be "SHUTTER OPEN" :-(
+        #
+        self.shutter_enabled = False 
 
         # these are NOT currently used by laser power settings, though they could be
         self.mod_enabled = False

--- a/wasatch/TCPDevice.py
+++ b/wasatch/TCPDevice.py
@@ -20,9 +20,8 @@ class TCPDevice(InterfaceDevice):
     ############################################################################
 
     def __init__(self, device_id, message_queue=None, alert_queue=None):
-        super().__init__()
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
-        self.device_id = device_id
         if device_id.type != "TCP":
             raise RuntimeError("TCPDevice can only be constructed with TCP DeviceID")
 

--- a/wasatch/USBCPowerConnectionState.py
+++ b/wasatch/USBCPowerConnectionState.py
@@ -1,17 +1,15 @@
-import logging
+import json
 from . import utils
 
-log = logging.getLogger(__name__)
-
-class USBCPowerConnectionState:
+class USBCPowerConnectionState(dict):
     """
     Making this a standalone class because might end up using from both FID (USB)
     and BLEDevice.
     """
     BC_12_ADAPTER_TYPES = {
-        1: "SDP",
-        2: "CDP",
-        3: "DCP" 
+        1: "SDP", # Standard Downstream Port
+        2: "CDP", # Charging Downstream Port
+        3: "DCP"  # Dedicated Charging Port
     }
 
     BC_12_CHARGER_TYPES = {
@@ -20,7 +18,7 @@ class USBCPowerConnectionState:
         3: "Apple 1A",
         4: "Apple 2A",
         5: "Apple 12W",
-        6: "DCP 3A",
+        6: "DCP 3A", # Dedicated Charging Port
         7: "Unknown"
     }
 
@@ -31,6 +29,8 @@ class USBCPowerConnectionState:
     }
 
     def __init__(self, data=None):
+        dict.__init__(self) # https://stackoverflow.com/a/31207881
+
         self.bc_12_adapter_type = None
         self.bc_12_charger_type = None
         self.type_c_cc_current_capability = None
@@ -87,3 +87,6 @@ class USBCPowerConnectionState:
 
     def __repr__(self):
         return self.short()
+
+    def toJSON(self):
+        return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=2)

--- a/wasatch/USBCPowerConnectionState.py
+++ b/wasatch/USBCPowerConnectionState.py
@@ -41,6 +41,9 @@ class USBCPowerConnectionState:
     def parse_data(self, data):
         """
         This is based on the data structure defined in ENG-0120 Rev 9.
+
+        BLE: 0x01 00 03 0b b8
+        USB: GET_POWER_CONNECTION_STATE: _get_code: request 0xff value 0x0078 index 0x0000 length 5 = [00 07 00 00 00]
         """
         if data is None or len(data) < 1:
             return
@@ -50,7 +53,23 @@ class USBCPowerConnectionState:
         if len(data) >= 3: self.type_c_cc_current_capability = self.TYPE_C_CC_CURRENT_CAPABILITY.get(data[2], None)
         if len(data) >= 5: self.current_limit_mA = (data[3] << 8) + data[4]
 
-    def __repr__(self):
+    def short(self):
+        tok = []
+        if self.bc_12_adapter_type: 
+            tok.append(self.bc_12_adapter_type)
+
+        if self.bc_12_charger_type: 
+            tok.append(self.bc_12_charger_type)
+
+        if self.type_c_cc_current_capability: 
+            tok.append(self.type_c_cc_current_capability)
+
+        if self.current_limit_mA: 
+            tok.append(f"{self.current_limit_mA}mA")
+
+        return "/".join(tok)
+
+    def long(self):
         tok = []
         if self.bc_12_adapter_type: 
             tok.append(f"BC 1.2 Adapter Type {self.bc_12_adapter_type}")
@@ -65,3 +84,6 @@ class USBCPowerConnectionState:
             tok.append(f"Current Limit {self.current_limit_mA}mA")
 
         return ", ".join(tok)
+
+    def __repr__(self):
+        return self.short()

--- a/wasatch/WasatchDevice.py
+++ b/wasatch/WasatchDevice.py
@@ -120,6 +120,7 @@ class WasatchDevice(InterfaceDevice):
         self.process_id = os.getpid()
         self.last_memory_check = datetime.datetime.now()
         self.last_battery_percentage = 0
+        self.late_arriving_timestamp = datetime.datetime.now()
 
         self.process_f = self._init_process_funcs()
 
@@ -608,6 +609,18 @@ class WasatchDevice(InterfaceDevice):
             else:
                 if reading is not None:
                     reading.battery_percentage = self.last_battery_percentage
+
+        # slow poll for late-arriving attributes
+        if self.settings.is_xs():
+            if (datetime.datetime.now() - self.late_arriving_timestamp).total_seconds() > 10:
+                self.late_arriving_timestamp = datetime.datetime.now()
+
+                # BLE Firmware Version
+                if not self.settings.ble_firmware_version:
+                    if not self.settings.eeprom.disable_ble_power:
+                        self.hardware.get_ble_firmware_version()
+                        if self.settings.ble_firmware_version:
+                            self.hardware.queue_message("received_ble_firmware_version", True)
 
         self.hardware.update_firmware_log()
 

--- a/wasatch/WasatchDevice.py
+++ b/wasatch/WasatchDevice.py
@@ -83,24 +83,13 @@ class WasatchDevice(InterfaceDevice):
     def __init__(self, device_id, message_queue=None, alert_queue=None):
         """
         @param device_id      a DeviceID instance OR string label thereof
-        @param message_queue  if provided, used to send status back to caller
-        @param alert_queue    if provided, used to receive hints and realtime interrupts from caller
         """
-        # if passed a string representation of a DeviceID, deserialize it
-        if type(device_id) is str:
-            device_id = DeviceID(label=device_id)
-
-        self.device_id      = device_id
-        self.message_queue  = message_queue # outgoing notifications to ENLIGHTEN
-        self.alert_queue    = alert_queue   # incoming alerts from ENLIGHTEN 
-
-        self.lock = threading.Lock()
+        super().__init__(device_id=device_id, message_queue=message_queue, alert_queue=alert_queue)
 
         self.connected = False
         self.hardware = None                # FeatureIdentificationDevice
 
-        # Receives ENLIGHTEN's 'change settings' commands in the spectrometer
-        # process. Although a logical queue, has nothing to do with multiprocessing.
+        # Receives ENLIGHTEN's 'change settings' commands from the WrapperWorker.
         self.command_queue = []
 
         # Enable for "immediate mode" by clients like WasatchShell (by default,
@@ -109,6 +98,7 @@ class WasatchDevice(InterfaceDevice):
         self.immediate_mode = False
 
         self.settings = SpectrometerSettings()
+        self.auto_raman = None
 
         # Any particular reason these aren't in FeatureIdentificationDevice?
         self.summed_spectra         = None
@@ -123,8 +113,6 @@ class WasatchDevice(InterfaceDevice):
         self.late_arriving_timestamp = datetime.datetime.now()
 
         self.process_f = self._init_process_funcs()
-
-        self.auto_raman = AutoRaman(self)
 
     # ######################################################################## #
     #                                                                          #
@@ -212,6 +200,11 @@ class WasatchDevice(InterfaceDevice):
         self.settings.update_wavecal()
         self.settings.update_raman_intensity_factors()
         self.settings.dump()
+
+        # AutoRaman takes an InterfaceDevice, and technically either 
+        # WasatchDevice or FeatureIdentificationDevice could probably work, but 
+        # leaning toward FID
+        self.auto_raman = AutoRaman(idevice=self.hardware)
 
     # ######################################################################## #
     #                                                                          #
@@ -366,11 +359,11 @@ class WasatchDevice(InterfaceDevice):
 
         dark_reading = SpectrometerResponse()
         if auto_enable_laser and tor.take_dark:
-            log.debug(f"AUTO-RAMAN ==> taking internal dark")
+            log.debug(f"OLD-AUTO-RAMAN ==> taking internal dark")
 
             # disable laser if it was on
             if self.settings.state.laser_enabled:
-                log.debug("AUTO-RAMAN ==> disabling laser for internal dark")
+                log.debug("OLD-AUTO-RAMAN ==> disabling laser for internal dark")
                 self.hardware.handle_requests([SpectrometerRequest('set_laser_enable', args=[False])])
                 time.sleep(1) 
 
@@ -384,7 +377,7 @@ class WasatchDevice(InterfaceDevice):
                 return acquire_response
 
         if auto_enable_laser:
-            log.debug(f"AUTO-RAMAN ==> acquire_spectum: enabling laser")
+            log.debug(f"OLD-AUTO-RAMAN ==> acquire_spectum: enabling laser")
             req = SpectrometerRequest('set_laser_enable', args=[True])
             self.hardware.handle_requests([req])
             if self.hardware.shutdown_requested:
@@ -393,7 +386,7 @@ class WasatchDevice(InterfaceDevice):
                 return acquire_response
 
             if tor:
-                log.debug(f"AUTO-RAMAN ==> acquire_spectum: sleeping {tor.laser_warmup_ms}ms for laser to warmup")
+                log.debug(f"OLD-AUTO-RAMAN ==> acquire_spectum: sleeping {tor.laser_warmup_ms}ms for laser to warmup")
                 time.sleep(tor.laser_warmup_ms / 1000.0)
 
             self.perform_optional_throwaways()
@@ -620,12 +613,12 @@ class WasatchDevice(InterfaceDevice):
                     if not self.settings.eeprom.disable_ble_power:
                         self.hardware.get_ble_firmware_version()
                         if self.settings.ble_firmware_version:
-                            self.hardware.queue_message("received_ble_firmware_version", True)
+                            self.queue_message("received_ble_firmware_version", True)
 
         self.hardware.update_firmware_log()
 
         if auto_enable_laser:
-            log.debug(f"AUTO-RAMAN ==> done")
+            log.debug(f"OLD-AUTO-RAMAN ==> done")
 
         if tor and not reading.keep_alive:
             reading.take_one_request = tor
@@ -1034,7 +1027,7 @@ class WasatchDevice(InterfaceDevice):
         As you can see in WasatchDevice._init_process_funcs, the only commands
         that _actually_ get executed from here are CONNECT, DISCONNECT and
         ACQUIRE_DATA. Everything else is going to get passed to change_setting,
-        which will localling process those few specific to WasatchDevice, then
+        which will locally process those few specific to WasatchDevice, then
         push the rest on command_queue for eventual ordered execution by 
         process_commands the next time acquire_data is called by WrapperWorker.
         """

--- a/wasatch/WasatchDevice.py
+++ b/wasatch/WasatchDevice.py
@@ -623,12 +623,21 @@ class WasatchDevice(InterfaceDevice):
         if tor and not reading.keep_alive:
             reading.take_one_request = tor
 
-            # this was for a "fast BatchCollection" with a streaming multi-reading TakeOneRequest
-            if tor.readings_target:
-                tor.readings_current += 1
+            # The populated readings_target indicates this was for a "fast 
+            # BatchCollection" with a streaming multi-reading TakeOneRequest.
+            # However, empirical testing demonstrated we don't want to increment
+            # readings_current here, because WasatchDevice and WrapperWorker DO 
+            # NOT KNOW how many Readings will be successfully received by the
+            # caller -- WasatchDeviceWrapper may "drop Readings on the floor" if
+            # the caller is not able to keep up with the stream. Therefore, we
+            # need to let the caller increment this upon successful receipt of
+            # each Reading. [#587]
+            #
+            # if tor.readings_target:
+            #     tor.readings_current += 1
 
             if not tor.readings_target or tor.readings_current >= tor.readings_target:
-                log.debug(f"completed {tor}")
+                log.debug(f"completed TakeOneRequest {tor} because no target ({tor.readings_target}) or current ({tor.readings_current}) >= target ({tor.readings_target})")
                 self.take_one_request = None
 
         log.debug("device.acquire_spectrum: returning %s", reading)

--- a/wasatch/WasatchDeviceWrapper.py
+++ b/wasatch/WasatchDeviceWrapper.py
@@ -111,6 +111,10 @@ log = logging.getLogger(__name__)
 #
 class WasatchDeviceWrapper:
 
+    # ##########################################################################
+    # Class Constants
+    # ##########################################################################
+
     ACQUISITION_MODE_KEEP_ALL      = 0 # don't drop frames
     ACQUISITION_MODE_LATEST        = 1 # only grab most-recent frame (allow dropping)
     ACQUISITION_MODE_KEEP_COMPLETE = 2 # generally grab most-recent frame (allow dropping),
@@ -119,7 +123,13 @@ class WasatchDeviceWrapper:
                                        # frame IS a partial summation contributor, then send it on.
 
     MAX_SETTINGS_POLL_SEC = 2
-    UNAVAILABLE_CLASS_NAMES = set()
+
+    # ##########################################################################
+    # Class Attributes
+    # ##########################################################################
+
+    unavailable_class_names = set()
+    interface_devices = set()
 
     # ##########################################################################
     #                                                                          #
@@ -129,7 +139,11 @@ class WasatchDeviceWrapper:
 
     @classmethod
     def is_device_class_available(cls, class_name):
-        return class_name not in cls.UNAVAILABLE_CLASS_NAMES
+        return class_name not in cls.unavailable_class_names
+
+    @classmethod
+    def get_interface_devices(cls):
+        return list(cls.interface_devices)
 
     # ##########################################################################
     #                                                                          #
@@ -303,16 +317,17 @@ class WasatchDeviceWrapper:
         elif isinstance(result.data, InterfaceDeviceClassUnavailable):
             response.error_msg = f"{self.class_name} unavailable"
             log.critical(f"poll_settings: {response.error_msg}")
-            self.UNAVAILABLE_CLASS_NAMES.add(self.class_name)
+            WasatchDeviceWrapper.unavailable_class_names.add(self.class_name)
 
         elif isinstance(result.data, SpectrometerSettings):
             # as long as no error_msg is set, ENLIGHTEN will interpret this as success
             # (note we're still just returning data=True)
             log.info(f"poll_settings: successfully received SpectrometerSettings for device")
             self.connected = True
-            self.settings = result.data 
             self.connect_start_time = datetime.datetime(year=datetime.MAXYEAR, month=1, day=1)
+            self.settings = result.data 
             self.settings.state.dump("WasatchDeviceWrapper.poll_settings")
+            WasatchDeviceWrapper.interface_devices.add(self.wrapper_worker.connected_device)
 
         else:
             response.error_msg = f"received unsupported result (neither SpectrometerSettings nor InterfaceDeviceClassUnavailable): {result}"
@@ -327,6 +342,8 @@ class WasatchDeviceWrapper:
     def disconnect(self):
         # send poison pill to the child
         self.closing = True
+        if self.wrapper_worker.connected_device:
+            WasatchDeviceWrapper.interface_devices.remove(self.wrapper_worker.connected_device)
         log.debug("disconnect: sending poison pill downstream")
         try:
             self.command_queue.put(None) 

--- a/wasatch/WasatchDeviceWrapper.py
+++ b/wasatch/WasatchDeviceWrapper.py
@@ -146,10 +146,11 @@ class WasatchDeviceWrapper:
     # could include "FILE:/path/to/dir", etc. However, device_id is just
     # a string scalar to this class, and actually parsing / using it should be
     # entirely encapsulated within WasatchDevice and lower using DeviceID.
-    def __init__(self, device_id, log_level, callback=None):
+    def __init__(self, device_id, log_level, callback=None, safe_mode=False):
         self.device_id = device_id
         self.log_level = log_level
         self.callback = callback
+        self.safe_mode = safe_mode
 
         self.settings_queue = Queue() # spectrometer -> GUI (SpectrometerSettings, one-time)
         self.response_queue = Queue() # spectrometer -> GUI (Readings)
@@ -237,7 +238,8 @@ class WasatchDeviceWrapper:
             message_queue  = self.message_queue,  # Main <-- child /  SpectrometerMessage?
             class_name     = self.class_name,
             log_level      = self.log_level,
-            callback       = self.callback)
+            callback       = self.callback,
+            safe_mode      = self.safe_mode)
         log.debug("device wrapper: Instance created for worker")
 
         self.wrapper_worker.daemon = True

--- a/wasatch/WasatchDeviceWrapper.py
+++ b/wasatch/WasatchDeviceWrapper.py
@@ -343,7 +343,11 @@ class WasatchDeviceWrapper:
         # send poison pill to the child
         self.closing = True
         if self.wrapper_worker.connected_device:
-            WasatchDeviceWrapper.interface_devices.remove(self.wrapper_worker.connected_device)
+            try:
+                WasatchDeviceWrapper.interface_devices.remove(self.wrapper_worker.connected_device)
+            except:
+                log.error("disconnect: failed to remove interface device", exc_info=1)
+
         log.debug("disconnect: sending poison pill downstream")
         try:
             self.command_queue.put(None) 

--- a/wasatch/WrapperWorker.py
+++ b/wasatch/WrapperWorker.py
@@ -66,6 +66,7 @@ class WrapperWorker(threading.Thread):
             class_name,
             log_level,
             callback=None,
+            safe_mode=False,
             alert_queue=None):
 
         threading.Thread.__init__(self)

--- a/wasatch/__init__.py
+++ b/wasatch/__init__.py
@@ -1,4 +1,4 @@
 """This package provides control of Wasatch Photonics spectrometers"""
 
-__version__ = "2.3.24"   # used by flit and other pypi things
+__version__ = "2.3.25"  # used by flit and other pypi things
 version = __version__   # legacy alias

--- a/wasatch/utils.py
+++ b/wasatch/utils.py
@@ -742,6 +742,18 @@ def to_hex(a):
         return "[ ]"
     return "[ " + ", ".join([f"0x{v:02x}" for v in a]) + " ]"
 
+def hex_string_to_data(s):
+    if s:
+        s = s.removeprefix("0x")
+    if s is None or not len(s):
+        return None
+    data = []
+    for i in range(len(s) // 2):
+        offset = i * 2
+        value = s[offset:offset + 2]
+        data.append(int(value, 16))
+    return data
+
 def from_db_to_linear(x):
     return 10 ** (x / 20.)
 


### PR DESCRIPTION
Big PR:

- 2026-??-?? 2.3.25
    - USB
        - enabled get_microcontroller_serial_number
        - testing get_power_connection_state
        - added periodic check for late-arriving attributes like ble_firmware_version
    - BLE
        - laser PWM works
    - Laser control
        - tweak laser password validation logic
        - add default laser warning delay sec for old FW
    - InterfaceDevice
        - moved message_queue, alert_queue up from WasatchDevice/FID
    - IDSDevice
        - added laser_device (incl EEPROM)
        - support Auto-Raman
    - EEPROM updates
        - bumped to version 19
        - consolidating backup location
        - deprecated baud_rate, linearity_coeffs
        - made EEPROM subclasses JSON serializable (hopefully)
        - fixed EEPROM.pack for binary types ("*")
        - moved further into (un)pack_field
        - revisited user_text / user_data relationship
        - added:
            - acc_cont_strobe_count
            - acc_cont_strobe_delay_us
            - acc_cont_strobe_period_us
            - acc_cont_strobe_width_us
            - acc_state
            - acc_state_gpio1
            - acc_state_gpio2
            - assembly_revision (and AssemblyRevision)
            - feature_mask_xs
            - light_source_type
            - max_battery_temp_deg_c
            - max_laser_temp_deg_c
            - pixel_calibration_type
            - startup_laser_tec_setpoint
    - starting to consider Safe Mode
